### PR TITLE
Add a custom recovery handler which includes the stack trace

### DIFF
--- a/check-headers.sh
+++ b/check-headers.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-files=$(find . -name \*.go -type f -print0 | xargs -0 egrep -L '(Licensed under the Apache License)|(Code generated from|by)')
+files=$(find . -name \*.go -type f -print0 | xargs -0 grep -L -E '(Licensed under the Apache License)|(Code generated (from|by))')
 if [ -n "$files" ]; then
   echo "Missing license header in:"
   echo "$files"

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -25,8 +25,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/dapperlabs/flow-playground-api/client"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dapperlabs/flow-playground-api/client"
 )
 
 func TestClient(t *testing.T) {

--- a/compute/cache.go
+++ b/compute/cache.go
@@ -20,7 +20,7 @@ package compute
 
 import (
 	"github.com/google/uuid"
-	"github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/pkg/errors"
 
 	"github.com/dapperlabs/flow-playground-api/model"

--- a/controller/embeds.go
+++ b/controller/embeds.go
@@ -21,15 +21,17 @@ package controller
 import (
 	"bytes"
 	"fmt"
+	"net/http"
+	"strings"
+
 	"github.com/alecthomas/chroma"
 	"github.com/alecthomas/chroma/formatters/html"
 	"github.com/alecthomas/chroma/lexers"
 	"github.com/alecthomas/chroma/styles"
+	"github.com/google/uuid"
+
 	"github.com/dapperlabs/flow-playground-api/model"
 	"github.com/dapperlabs/flow-playground-api/storage"
-	"github.com/google/uuid"
-	"net/http"
-	"strings"
 )
 
 type Snippet struct {

--- a/controller/embeds_test.go
+++ b/controller/embeds_test.go
@@ -21,20 +21,22 @@ package controller
 import (
 	"context"
 	"fmt"
-	"github.com/Masterminds/semver"
-	"github.com/alecthomas/assert"
-	"github.com/dapperlabs/flow-playground-api/model"
-	"github.com/dapperlabs/flow-playground-api/storage/memory"
-	"github.com/go-chi/chi"
-	"github.com/google/uuid"
-	"github.com/onflow/flow-go/engine/execution/state/delta"
-	"github.com/stretchr/testify/require"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/Masterminds/semver"
+	"github.com/alecthomas/assert"
+	"github.com/go-chi/chi"
+	"github.com/google/uuid"
+	"github.com/onflow/flow-go/engine/execution/state/delta"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapperlabs/flow-playground-api/model"
+	"github.com/dapperlabs/flow-playground-api/storage/memory"
 )
 
 // version to create project

--- a/controller/utils.go
+++ b/controller/utils.go
@@ -19,9 +19,10 @@
 package controller
 
 import (
+	"net/http"
+
 	"github.com/go-chi/render"
 	"github.com/onflow/cadence"
-	"net/http"
 )
 
 type UtilsHandler struct{}

--- a/handler.go
+++ b/handler.go
@@ -1,0 +1,43 @@
+/*
+ * Flow Playground
+ *
+ * Copyright 2019-2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package playground
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"runtime/debug"
+
+	"github.com/99designs/gqlgen/handler"
+)
+
+func GraphQLHandler(resolver *Resolver, options ...handler.Option) http.HandlerFunc {
+
+	options = append(
+		options,
+		handler.RecoverFunc(func(ctx context.Context, err interface{}) (userMessage error) {
+			return fmt.Errorf("panic: %s\n\n%s", err, string(debug.Stack()))
+		}),
+	)
+
+	return handler.GraphQL(
+		NewExecutableSchema(Config{Resolvers: resolver}),
+		options...,
+	)
+}

--- a/playground_test.go
+++ b/playground_test.go
@@ -28,7 +28,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/99designs/gqlgen/handler"
 	"github.com/Masterminds/semver"
 	"github.com/go-chi/chi"
 	"github.com/google/uuid"
@@ -447,12 +446,13 @@ func TestProjects(t *testing.T) {
 
 		var resp CreateProjectResponse
 
-		c.MustPost(
+		err := c.Post(
 			MutationCreateProject,
 			&resp,
 			client.Var("title", "foo"),
 			client.Var("seed", 42),
 		)
+		require.NoError(t, err)
 
 		assert.NotEmpty(t, resp.CreateProject.ID)
 		assert.Equal(t, 42, resp.CreateProject.Seed)
@@ -475,13 +475,14 @@ func TestProjects(t *testing.T) {
 			"pub contract Bar {}",
 		}
 
-		c.MustPost(
+		err := c.Post(
 			MutationCreateProject,
 			&resp,
 			client.Var("title", "foo"),
 			client.Var("seed", 42),
 			client.Var("accounts", accounts),
 		)
+		require.NoError(t, err)
 
 		// project should still be created with 4 default accounts
 		assert.Len(t, resp.CreateProject.Accounts, playground.MaxAccounts)
@@ -503,13 +504,14 @@ func TestProjects(t *testing.T) {
 			"pub contract Cat {}",
 		}
 
-		c.MustPost(
+		err := c.Post(
 			MutationCreateProject,
 			&resp,
 			client.Var("title", "foo"),
 			client.Var("seed", 42),
 			client.Var("accounts", accounts),
 		)
+		require.NoError(t, err)
 
 		// project should still be created with 4 default accounts
 		assert.Len(t, resp.CreateProject.Accounts, playground.MaxAccounts)
@@ -536,13 +538,14 @@ func TestProjects(t *testing.T) {
 			},
 		}
 
-		c.MustPost(
+		err := c.Post(
 			MutationCreateProject,
 			&resp,
 			client.Var("title", "foo"),
 			client.Var("seed", 42),
 			client.Var("transactionTemplates", templates),
 		)
+		require.NoError(t, err)
 
 		assert.Len(t, resp.CreateProject.TransactionTemplates, 2)
 		assert.Equal(t, templates[0].Title, resp.CreateProject.TransactionTemplates[0].Title)
@@ -554,15 +557,16 @@ func TestProjects(t *testing.T) {
 	t.Run("Get project", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp GetProjectResponse
 
-		c.MustPost(
+		err := c.Post(
 			QueryGetProject,
 			&resp,
 			client.Var("projectId", project.ID),
 		)
+		require.NoError(t, err)
 
 		assert.Equal(t, project.ID, resp.Project.ID)
 	})
@@ -586,7 +590,7 @@ func TestProjects(t *testing.T) {
 	t.Run("Persist project without permission", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp UpdateProjectResponse
 
@@ -603,17 +607,18 @@ func TestProjects(t *testing.T) {
 	t.Run("Persist project", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp UpdateProjectResponse
 
-		c.MustPost(
+		err := c.Post(
 			MutationUpdateProjectPersist,
 			&resp,
 			client.Var("projectId", project.ID),
 			client.Var("persist", true),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		assert.Equal(t, project.ID, resp.UpdateProject.ID)
 		assert.True(t, resp.UpdateProject.Persist)
@@ -624,7 +629,7 @@ func TestTransactionTemplates(t *testing.T) {
 	t.Run("Create transaction template without permission", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp CreateTransactionTemplateResponse
 
@@ -643,11 +648,11 @@ func TestTransactionTemplates(t *testing.T) {
 	t.Run("Create transaction template", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp CreateTransactionTemplateResponse
 
-		c.MustPost(
+		err := c.Post(
 			MutationCreateTransactionTemplate,
 			&resp,
 			client.Var("projectId", project.ID),
@@ -655,6 +660,7 @@ func TestTransactionTemplates(t *testing.T) {
 			client.Var("script", "bar"),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		assert.NotEmpty(t, resp.CreateTransactionTemplate.ID)
 		assert.Equal(t, "foo", resp.CreateTransactionTemplate.Title)
@@ -664,11 +670,11 @@ func TestTransactionTemplates(t *testing.T) {
 	t.Run("Get transaction template", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var respA CreateTransactionTemplateResponse
 
-		c.MustPost(
+		err := c.Post(
 			MutationCreateTransactionTemplate,
 			&respA,
 			client.Var("projectId", project.ID),
@@ -676,15 +682,17 @@ func TestTransactionTemplates(t *testing.T) {
 			client.Var("script", "bar"),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		var respB GetTransactionTemplateResponse
 
-		c.MustPost(
+		err = c.Post(
 			QueryGetTransactionTemplate,
 			&respB,
 			client.Var("projectId", project.ID),
 			client.Var("templateId", respA.CreateTransactionTemplate.ID),
 		)
+		require.NoError(t, err)
 
 		assert.Equal(t, respA.CreateTransactionTemplate.ID, respB.TransactionTemplate.ID)
 		assert.Equal(t, respA.CreateTransactionTemplate.Script, respB.TransactionTemplate.Script)
@@ -693,7 +701,7 @@ func TestTransactionTemplates(t *testing.T) {
 	t.Run("Get non-existent transaction template", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp GetTransactionTemplateResponse
 
@@ -712,11 +720,11 @@ func TestTransactionTemplates(t *testing.T) {
 	t.Run("Update transaction template without permission", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var respA CreateTransactionTemplateResponse
 
-		c.MustPost(
+		err := c.Post(
 			MutationCreateTransactionTemplate,
 			&respA,
 			client.Var("projectId", project.ID),
@@ -724,30 +732,30 @@ func TestTransactionTemplates(t *testing.T) {
 			client.Var("script", "apple"),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		templateID := respA.CreateTransactionTemplate.ID
 
 		var respB UpdateTransactionTemplateResponse
 
-		err := c.Post(
+		err = c.Post(
 			MutationUpdateTransactionTemplateScript,
 			&respB,
 			client.Var("projectId", project.ID),
 			client.Var("templateId", templateID),
 			client.Var("script", "orange"),
 		)
-
 		assert.Error(t, err)
 	})
 
 	t.Run("Update transaction template", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var respA CreateTransactionTemplateResponse
 
-		c.MustPost(
+		err := c.Post(
 			MutationCreateTransactionTemplate,
 			&respA,
 			client.Var("projectId", project.ID),
@@ -755,12 +763,13 @@ func TestTransactionTemplates(t *testing.T) {
 			client.Var("script", "apple"),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		templateID := respA.CreateTransactionTemplate.ID
 
 		var respB UpdateTransactionTemplateResponse
 
-		c.MustPost(
+		err = c.Post(
 			MutationUpdateTransactionTemplateScript,
 			&respB,
 			client.Var("projectId", project.ID),
@@ -768,6 +777,7 @@ func TestTransactionTemplates(t *testing.T) {
 			client.Var("script", "orange"),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		assert.Equal(t, respA.CreateTransactionTemplate.ID, respB.UpdateTransactionTemplate.ID)
 		assert.Equal(t, respA.CreateTransactionTemplate.Index, respB.UpdateTransactionTemplate.Index)
@@ -781,7 +791,7 @@ func TestTransactionTemplates(t *testing.T) {
 			}
 		}
 
-		c.MustPost(
+		err = c.Post(
 			MutationUpdateTransactionTemplateIndex,
 			&respC,
 			client.Var("projectId", project.ID),
@@ -789,6 +799,7 @@ func TestTransactionTemplates(t *testing.T) {
 			client.Var("index", 1),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		assert.Equal(t, respA.CreateTransactionTemplate.ID, respC.UpdateTransactionTemplate.ID)
 		assert.Equal(t, 1, respC.UpdateTransactionTemplate.Index)
@@ -798,7 +809,7 @@ func TestTransactionTemplates(t *testing.T) {
 	t.Run("Update non-existent transaction template", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp UpdateTransactionTemplateResponse
 
@@ -818,19 +829,20 @@ func TestTransactionTemplates(t *testing.T) {
 	t.Run("Get transaction templates for project", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
-		templateA := createTransactionTemplate(c, project)
-		templateB := createTransactionTemplate(c, project)
-		templateC := createTransactionTemplate(c, project)
+		templateA := createTransactionTemplate(t, c, project)
+		templateB := createTransactionTemplate(t, c, project)
+		templateC := createTransactionTemplate(t, c, project)
 
 		var resp GetProjectTransactionTemplatesResponse
 
-		c.MustPost(
+		err := c.Post(
 			QueryGetProjectTransactionTemplates,
 			&resp,
 			client.Var("projectId", project.ID),
 		)
+		require.NoError(t, err)
 
 		assert.Len(t, resp.Project.TransactionTemplates, 3)
 		assert.Equal(t, templateA.ID, resp.Project.TransactionTemplates[0].ID)
@@ -861,9 +873,9 @@ func TestTransactionTemplates(t *testing.T) {
 	t.Run("Delete transaction template without permission", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
-		template := createTransactionTemplate(c, project)
+		template := createTransactionTemplate(t, c, project)
 
 		var resp DeleteTransactionTemplateResponse
 
@@ -881,19 +893,20 @@ func TestTransactionTemplates(t *testing.T) {
 	t.Run("Delete transaction template", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
-		template := createTransactionTemplate(c, project)
+		template := createTransactionTemplate(t, c, project)
 
 		var resp DeleteTransactionTemplateResponse
 
-		c.MustPost(
+		err := c.Post(
 			MutationDeleteTransactionTemplate,
 			&resp,
 			client.Var("projectId", project.ID),
 			client.Var("templateId", template.ID),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		assert.Equal(t, template.ID, resp.DeleteTransactionTemplate)
 	})
@@ -920,7 +933,7 @@ func TestTransactionExecutions(t *testing.T) {
 	t.Run("Create execution without permission", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp CreateTransactionExecutionResponse
 
@@ -939,19 +952,20 @@ func TestTransactionExecutions(t *testing.T) {
 	t.Run("Create execution", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp CreateTransactionExecutionResponse
 
 		const script = "transaction { execute { log(\"Hello, World!\") } }"
 
-		c.MustPost(
+		err := c.Post(
 			MutationCreateTransactionExecution,
 			&resp,
 			client.Var("projectId", project.ID),
 			client.Var("script", script),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		assert.Empty(t, resp.CreateTransactionExecution.Errors)
 		assert.Contains(t, resp.CreateTransactionExecution.Logs, "\"Hello, World!\"")
@@ -961,13 +975,13 @@ func TestTransactionExecutions(t *testing.T) {
 	t.Run("Multiple executions", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var respA CreateTransactionExecutionResponse
 
 		const script = "transaction { prepare(signer: AuthAccount) { AuthAccount(payer: signer) } }"
 
-		c.MustPost(
+		err := c.Post(
 			MutationCreateTransactionExecution,
 			&respA,
 			client.Var("projectId", project.ID),
@@ -975,6 +989,7 @@ func TestTransactionExecutions(t *testing.T) {
 			client.Var("signers", []string{project.Accounts[0].Address}),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		require.Empty(t, respA.CreateTransactionExecution.Errors)
 		require.Len(t, respA.CreateTransactionExecution.Events, 1)
@@ -990,7 +1005,7 @@ func TestTransactionExecutions(t *testing.T) {
 
 		var respB CreateTransactionExecutionResponse
 
-		c.MustPost(
+		err = c.Post(
 			MutationCreateTransactionExecution,
 			&respB,
 			client.Var("projectId", project.ID),
@@ -998,6 +1013,7 @@ func TestTransactionExecutions(t *testing.T) {
 			client.Var("signers", []string{project.Accounts[0].Address}),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		require.Empty(t, respB.CreateTransactionExecution.Errors)
 		require.Len(t, respB.CreateTransactionExecution.Events, 1)
@@ -1021,13 +1037,13 @@ func TestTransactionExecutions(t *testing.T) {
 
 		c := newClientWithResolver(resolver)
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var respA CreateTransactionExecutionResponse
 
 		const script = "transaction { prepare(signer: AuthAccount) { AuthAccount(payer: signer) } }"
 
-		c.MustPost(
+		err := c.Post(
 			MutationCreateTransactionExecution,
 			&respA,
 			client.Var("projectId", project.ID),
@@ -1035,6 +1051,7 @@ func TestTransactionExecutions(t *testing.T) {
 			client.Var("signers", []string{project.Accounts[0].Address}),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		require.Empty(t, respA.CreateTransactionExecution.Errors)
 		require.Len(t, respA.CreateTransactionExecution.Events, 1)
@@ -1053,7 +1070,7 @@ func TestTransactionExecutions(t *testing.T) {
 
 		var respB CreateTransactionExecutionResponse
 
-		c.MustPost(
+		err = c.Post(
 			MutationCreateTransactionExecution,
 			&respB,
 			client.Var("projectId", project.ID),
@@ -1061,6 +1078,7 @@ func TestTransactionExecutions(t *testing.T) {
 			client.Var("signers", []string{project.Accounts[0].Address}),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		require.Len(t, respB.CreateTransactionExecution.Events, 1)
 
@@ -1077,7 +1095,7 @@ func TestTransactionExecutions(t *testing.T) {
 	t.Run("invalid (parse error)", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp CreateTransactionExecutionResponse
 
@@ -1085,13 +1103,14 @@ func TestTransactionExecutions(t *testing.T) {
           transaction(a: Int) {
         `
 
-		c.MustPost(
+		err := c.Post(
 			MutationCreateTransactionExecution,
 			&resp,
 			client.Var("projectId", project.ID),
 			client.Var("script", script),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		require.Equal(t,
 			[]model.ProgramError{
@@ -1117,7 +1136,7 @@ func TestTransactionExecutions(t *testing.T) {
 	t.Run("invalid (semantic error)", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp CreateTransactionExecutionResponse
 
@@ -1125,13 +1144,14 @@ func TestTransactionExecutions(t *testing.T) {
           transaction { execute { XYZ } }
         `
 
-		c.MustPost(
+		err := c.Post(
 			MutationCreateTransactionExecution,
 			&resp,
 			client.Var("projectId", project.ID),
 			client.Var("script", script),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		require.Equal(t,
 			[]model.ProgramError{
@@ -1157,7 +1177,7 @@ func TestTransactionExecutions(t *testing.T) {
 	t.Run("invalid (run-time error)", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp CreateTransactionExecutionResponse
 
@@ -1165,13 +1185,14 @@ func TestTransactionExecutions(t *testing.T) {
           transaction { execute { panic("oh no") } }
         `
 
-		c.MustPost(
+		err := c.Post(
 			MutationCreateTransactionExecution,
 			&resp,
 			client.Var("projectId", project.ID),
 			client.Var("script", script),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		require.Equal(t,
 			[]model.ProgramError{
@@ -1197,7 +1218,7 @@ func TestTransactionExecutions(t *testing.T) {
 	t.Run("exceeding computation limit", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp CreateTransactionExecutionResponse
 
@@ -1212,13 +1233,14 @@ func TestTransactionExecutions(t *testing.T) {
           }
         `
 
-		c.MustPost(
+		err := c.Post(
 			MutationCreateTransactionExecution,
 			&resp,
 			client.Var("projectId", project.ID),
 			client.Var("script", script),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		assert.Equal(t, script, resp.CreateTransactionExecution.Script)
 		require.Equal(t,
@@ -1244,7 +1266,7 @@ func TestTransactionExecutions(t *testing.T) {
 	t.Run("argument", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp CreateTransactionExecutionResponse
 
@@ -1256,7 +1278,7 @@ func TestTransactionExecutions(t *testing.T) {
           }
         `
 
-		c.MustPost(
+		err := c.Post(
 			MutationCreateTransactionExecution,
 			&resp,
 			client.Var("projectId", project.ID),
@@ -1266,6 +1288,7 @@ func TestTransactionExecutions(t *testing.T) {
 			}),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		require.Empty(t, resp.CreateTransactionExecution.Errors)
 		require.Equal(t, resp.CreateTransactionExecution.Logs, []string{"42"})
@@ -1276,7 +1299,7 @@ func TestScriptTemplates(t *testing.T) {
 	t.Run("Create script template without permission", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp CreateScriptTemplateResponse
 
@@ -1295,11 +1318,11 @@ func TestScriptTemplates(t *testing.T) {
 	t.Run("Create script template", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp CreateScriptTemplateResponse
 
-		c.MustPost(
+		err := c.Post(
 			MutationCreateScriptTemplate,
 			&resp,
 			client.Var("projectId", project.ID),
@@ -1307,6 +1330,7 @@ func TestScriptTemplates(t *testing.T) {
 			client.Var("script", "bar"),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		assert.NotEmpty(t, resp.CreateScriptTemplate.ID)
 		assert.Equal(t, "foo", resp.CreateScriptTemplate.Title)
@@ -1316,11 +1340,11 @@ func TestScriptTemplates(t *testing.T) {
 	t.Run("Get script template", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var respA CreateScriptTemplateResponse
 
-		c.MustPost(
+		err := c.Post(
 			MutationCreateScriptTemplate,
 			&respA,
 			client.Var("projectId", project.ID),
@@ -1328,15 +1352,17 @@ func TestScriptTemplates(t *testing.T) {
 			client.Var("script", "bar"),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		var respB GetScriptTemplateResponse
 
-		c.MustPost(
+		err = c.Post(
 			QueryGetScriptTemplate,
 			&respB,
 			client.Var("projectId", project.ID),
 			client.Var("templateId", respA.CreateScriptTemplate.ID),
 		)
+		require.NoError(t, err)
 
 		assert.Equal(t, respA.CreateScriptTemplate.ID, respB.ScriptTemplate.ID)
 		assert.Equal(t, respA.CreateScriptTemplate.Script, respB.ScriptTemplate.Script)
@@ -1345,7 +1371,7 @@ func TestScriptTemplates(t *testing.T) {
 	t.Run("Get non-existent script template", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp GetScriptTemplateResponse
 
@@ -1364,11 +1390,11 @@ func TestScriptTemplates(t *testing.T) {
 	t.Run("Update script template without permission", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var respA CreateScriptTemplateResponse
 
-		c.MustPost(
+		err := c.Post(
 			MutationCreateScriptTemplate,
 			&respA,
 			client.Var("projectId", project.ID),
@@ -1376,30 +1402,30 @@ func TestScriptTemplates(t *testing.T) {
 			client.Var("script", "apple"),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		templateID := respA.CreateScriptTemplate.ID
 
 		var respB UpdateScriptTemplateResponse
 
-		err := c.Post(
+		err = c.Post(
 			MutationUpdateScriptTemplateScript,
 			&respB,
 			client.Var("projectId", project.ID),
 			client.Var("templateId", templateID),
 			client.Var("script", "orange"),
 		)
-
 		assert.Error(t, err)
 	})
 
 	t.Run("Update script template", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var respA CreateScriptTemplateResponse
 
-		c.MustPost(
+		err := c.Post(
 			MutationCreateScriptTemplate,
 			&respA,
 			client.Var("projectId", project.ID),
@@ -1407,12 +1433,13 @@ func TestScriptTemplates(t *testing.T) {
 			client.Var("script", "apple"),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		templateID := respA.CreateScriptTemplate.ID
 
 		var respB UpdateScriptTemplateResponse
 
-		c.MustPost(
+		err = c.Post(
 			MutationUpdateScriptTemplateScript,
 			&respB,
 			client.Var("projectId", project.ID),
@@ -1420,6 +1447,7 @@ func TestScriptTemplates(t *testing.T) {
 			client.Var("script", "orange"),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		assert.Equal(t, respA.CreateScriptTemplate.ID, respB.UpdateScriptTemplate.ID)
 		assert.Equal(t, respA.CreateScriptTemplate.Index, respB.UpdateScriptTemplate.Index)
@@ -1427,7 +1455,7 @@ func TestScriptTemplates(t *testing.T) {
 
 		var respC UpdateScriptTemplateResponse
 
-		c.MustPost(
+		err = c.Post(
 			MutationUpdateScriptTemplateIndex,
 			&respC,
 			client.Var("projectId", project.ID),
@@ -1435,6 +1463,7 @@ func TestScriptTemplates(t *testing.T) {
 			client.Var("index", 1),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		assert.Equal(t, respA.CreateScriptTemplate.ID, respC.UpdateScriptTemplate.ID)
 		assert.Equal(t, 1, respC.UpdateScriptTemplate.Index)
@@ -1444,7 +1473,7 @@ func TestScriptTemplates(t *testing.T) {
 	t.Run("Update non-existent script template", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp UpdateScriptTemplateResponse
 
@@ -1464,19 +1493,20 @@ func TestScriptTemplates(t *testing.T) {
 	t.Run("Get script templates for project", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
-		templateIDA := createScriptTemplate(c, project)
-		templateIDB := createScriptTemplate(c, project)
-		templateIDC := createScriptTemplate(c, project)
+		templateIDA := createScriptTemplate(t, c, project)
+		templateIDB := createScriptTemplate(t, c, project)
+		templateIDC := createScriptTemplate(t, c, project)
 
 		var resp GetProjectScriptTemplatesResponse
 
-		c.MustPost(
+		err := c.Post(
 			QueryGetProjectScriptTemplates,
 			&resp,
 			client.Var("projectId", project.ID),
 		)
+		require.NoError(t, err)
 
 		assert.Len(t, resp.Project.ScriptTemplates, 3)
 		assert.Equal(t, templateIDA, resp.Project.ScriptTemplates[0].ID)
@@ -1508,9 +1538,9 @@ func TestScriptTemplates(t *testing.T) {
 	t.Run("Delete script template without permission", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
-		templateID := createScriptTemplate(c, project)
+		templateID := createScriptTemplate(t, c, project)
 
 		var resp DeleteScriptTemplateResponse
 
@@ -1527,19 +1557,20 @@ func TestScriptTemplates(t *testing.T) {
 	t.Run("Delete script template", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
-		templateID := createScriptTemplate(c, project)
+		templateID := createScriptTemplate(t, c, project)
 
 		var resp DeleteScriptTemplateResponse
 
-		c.MustPost(
+		err := c.Post(
 			MutationDeleteScriptTemplate,
 			&resp,
 			client.Var("projectId", project.ID),
 			client.Var("templateId", templateID),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		assert.Equal(t, templateID, resp.DeleteScriptTemplate)
 	})
@@ -1549,17 +1580,18 @@ func TestAccounts(t *testing.T) {
 	t.Run("Get account", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 		account := project.Accounts[0]
 
 		var resp GetAccountResponse
 
-		c.MustPost(
+		err := c.Post(
 			QueryGetAccount,
 			&resp,
 			client.Var("projectId", project.ID),
 			client.Var("accountId", account.ID),
 		)
+		require.NoError(t, err)
 
 		assert.Equal(t, account.ID, resp.Account.ID)
 	})
@@ -1567,7 +1599,7 @@ func TestAccounts(t *testing.T) {
 	t.Run("Get non-existent account", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp GetAccountResponse
 
@@ -1586,23 +1618,24 @@ func TestAccounts(t *testing.T) {
 	t.Run("Update account draft code without permission", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 		account := project.Accounts[0]
 
 		var respA GetAccountResponse
 
-		c.MustPost(
+		err := c.Post(
 			QueryGetAccount,
 			&respA,
 			client.Var("projectId", project.ID),
 			client.Var("accountId", account.ID),
 		)
+		require.NoError(t, err)
 
 		assert.Equal(t, "", respA.Account.DraftCode)
 
 		var respB UpdateAccountResponse
 
-		err := c.Post(
+		err = c.Post(
 			MutationUpdateAccountDraftCode,
 			&respB,
 			client.Var("projectId", project.ID),
@@ -1616,23 +1649,24 @@ func TestAccounts(t *testing.T) {
 	t.Run("Update account draft code", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 		account := project.Accounts[0]
 
 		var respA GetAccountResponse
 
-		c.MustPost(
+		err := c.Post(
 			QueryGetAccount,
 			&respA,
 			client.Var("projectId", project.ID),
 			client.Var("accountId", account.ID),
 		)
+		require.NoError(t, err)
 
 		assert.Equal(t, "", respA.Account.DraftCode)
 
 		var respB UpdateAccountResponse
 
-		c.MustPost(
+		err = c.Post(
 			MutationUpdateAccountDraftCode,
 			&respB,
 			client.Var("projectId", project.ID),
@@ -1640,6 +1674,7 @@ func TestAccounts(t *testing.T) {
 			client.Var("code", "bar"),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		assert.Equal(t, "bar", respB.UpdateAccount.DraftCode)
 	})
@@ -1647,23 +1682,24 @@ func TestAccounts(t *testing.T) {
 	t.Run("Update account invalid deployed code", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 		account := project.Accounts[0]
 
 		var respA GetAccountResponse
 
-		c.MustPost(
+		err := c.Post(
 			QueryGetAccount,
 			&respA,
 			client.Var("projectId", project.ID),
 			client.Var("accountId", account.ID),
 		)
+		require.NoError(t, err)
 
 		assert.Equal(t, "", respA.Account.DeployedCode)
 
 		var respB UpdateAccountResponse
 
-		err := c.Post(
+		err = c.Post(
 			MutationUpdateAccountDeployedCode,
 			&respB,
 			client.Var("projectId", project.ID),
@@ -1678,7 +1714,7 @@ func TestAccounts(t *testing.T) {
 	t.Run("Update account deployed code without permission", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		account := project.Accounts[0]
 
@@ -1700,18 +1736,19 @@ func TestAccounts(t *testing.T) {
 	t.Run("Update account deployed code", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		account := project.Accounts[0]
 
 		var respA GetAccountResponse
 
-		c.MustPost(
+		err := c.Post(
 			QueryGetAccount,
 			&respA,
 			client.Var("projectId", project.ID),
 			client.Var("accountId", account.ID),
 		)
+		require.NoError(t, err)
 
 		assert.Equal(t, "", respA.Account.DeployedCode)
 
@@ -1719,7 +1756,7 @@ func TestAccounts(t *testing.T) {
 
 		const contract = "pub contract Foo {}"
 
-		c.MustPost(
+		err = c.Post(
 			MutationUpdateAccountDeployedCode,
 			&respB,
 			client.Var("projectId", project.ID),
@@ -1727,6 +1764,7 @@ func TestAccounts(t *testing.T) {
 			client.Var("code", contract),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		assert.Equal(t, contract, respB.UpdateAccount.DeployedCode)
 	})
@@ -1734,7 +1772,7 @@ func TestAccounts(t *testing.T) {
 	t.Run("Update non-existent account", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp UpdateAccountResponse
 
@@ -1801,14 +1839,14 @@ func generateAddTwoToCounterScript(counterAddress string) string {
 func TestContractInteraction(t *testing.T) {
 	c := newClient()
 
-	project := createProject(c)
+	project := createProject(t, c)
 
 	accountA := project.Accounts[0]
 	accountB := project.Accounts[1]
 
 	var respA UpdateAccountResponse
 
-	c.MustPost(
+	err := c.Post(
 		MutationUpdateAccountDeployedCode,
 		&respA,
 		client.Var("projectId", project.ID),
@@ -1816,6 +1854,7 @@ func TestContractInteraction(t *testing.T) {
 		client.Var("code", counterContract),
 		client.AddCookie(c.SessionCookie()),
 	)
+	require.NoError(t, err)
 
 	assert.Equal(t, counterContract, respA.UpdateAccount.DeployedCode)
 
@@ -1823,7 +1862,7 @@ func TestContractInteraction(t *testing.T) {
 
 	var respB CreateTransactionExecutionResponse
 
-	c.MustPost(
+	err = c.Post(
 		MutationCreateTransactionExecution,
 		&respB,
 		client.Var("projectId", project.ID),
@@ -1831,6 +1870,7 @@ func TestContractInteraction(t *testing.T) {
 		client.Var("signers", []string{accountB.Address}),
 		client.AddCookie(c.SessionCookie()),
 	)
+	require.NoError(t, err)
 
 	assert.Empty(t, respB.CreateTransactionExecution.Errors)
 }
@@ -1839,7 +1879,7 @@ func TestAuthentication(t *testing.T) {
 	t.Run("Migrate legacy auth", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var respA UpdateProjectResponse
 
@@ -1848,13 +1888,14 @@ func TestAuthentication(t *testing.T) {
 		// clear session cookie before making request
 		c.ClearSessionCookie()
 
-		c.MustPost(
+		err := c.Post(
 			MutationUpdateProjectPersist,
 			&respA,
 			client.Var("projectId", project.ID),
 			client.Var("persist", true),
 			client.AddCookie(legacyauth.MockProjectSessionCookie(project.ID, project.Secret)),
 		)
+		require.NoError(t, err)
 
 		assert.Equal(t, project.ID, respA.UpdateProject.ID)
 		assert.True(t, respA.UpdateProject.Persist)
@@ -1865,13 +1906,14 @@ func TestAuthentication(t *testing.T) {
 
 		var respB UpdateProjectResponse
 
-		c.MustPost(
+		err = c.Post(
 			MutationUpdateProjectPersist,
 			&respB,
 			client.Var("projectId", project.ID),
 			client.Var("persist", false),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		// should be able to perform update using new session cookie
 		assert.Equal(t, project.ID, respB.UpdateProject.ID)
@@ -1888,13 +1930,14 @@ func TestAuthentication(t *testing.T) {
 			Value: "foo",
 		}
 
-		c.MustPost(
+		err := c.Post(
 			MutationCreateProject,
 			&respA,
 			client.Var("title", "foo"),
 			client.Var("seed", 42),
 			client.AddCookie(&malformedCookie),
 		)
+		require.NoError(t, err)
 
 		projectID := respA.CreateProject.ID
 
@@ -1906,13 +1949,14 @@ func TestAuthentication(t *testing.T) {
 
 		var respB UpdateProjectResponse
 
-		c.MustPost(
+		err = c.Post(
 			MutationUpdateProjectPersist,
 			&respB,
 			client.Var("projectId", projectID),
 			client.Var("persist", true),
 			client.AddCookie(c.SessionCookie()),
 		)
+		require.NoError(t, err)
 
 		// should be able to perform update using new session cookie
 		assert.Equal(t, projectID, respB.UpdateProject.ID)
@@ -1922,7 +1966,7 @@ func TestAuthentication(t *testing.T) {
 	t.Run("Update project with malformed session cookie", func(t *testing.T) {
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp UpdateProjectResponse
 
@@ -1950,8 +1994,8 @@ func TestAuthentication(t *testing.T) {
 	t.Run("Update project with invalid session cookie", func(t *testing.T) {
 		c := newClient()
 
-		projectA := createProject(c)
-		_ = createProject(c)
+		projectA := createProject(t, c)
+		_ = createProject(t, c)
 
 		cookieB := c.SessionCookie()
 
@@ -1976,7 +2020,7 @@ func TestScriptExecutions(t *testing.T) {
 
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp CreateScriptExecutionResponse
 
@@ -1998,7 +2042,7 @@ func TestScriptExecutions(t *testing.T) {
 
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp CreateScriptExecutionResponse
 
@@ -2038,7 +2082,7 @@ func TestScriptExecutions(t *testing.T) {
 
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp CreateScriptExecutionResponse
 
@@ -2078,7 +2122,7 @@ func TestScriptExecutions(t *testing.T) {
 
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp CreateScriptExecutionResponse
 
@@ -2118,7 +2162,7 @@ func TestScriptExecutions(t *testing.T) {
 
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp CreateScriptExecutionResponse
 
@@ -2165,7 +2209,7 @@ func TestScriptExecutions(t *testing.T) {
 
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp CreateScriptExecutionResponse
 
@@ -2192,7 +2236,7 @@ func TestScriptExecutions(t *testing.T) {
 
 		c := newClient()
 
-		project := createProject(c)
+		project := createProject(t, c)
 
 		var resp CreateScriptExecutionResponse
 
@@ -2299,10 +2343,10 @@ func newClientWithResolver(resolver *playground.Resolver) *Client {
 	}
 }
 
-func createProject(c *Client) Project {
+func createProject(t *testing.T, c *Client) Project {
 	var resp CreateProjectResponse
 
-	c.MustPost(
+	err := c.Post(
 		MutationCreateProject,
 		&resp,
 		client.Var("title", "foo"),
@@ -2310,6 +2354,7 @@ func createProject(c *Client) Project {
 		client.Var("accounts", []string{}),
 		client.Var("transactionTemplates", []string{}),
 	)
+	require.NoError(t, err)
 
 	proj := resp.CreateProject
 	internalProj := c.resolver.LastCreatedProject()
@@ -2319,10 +2364,10 @@ func createProject(c *Client) Project {
 	return proj
 }
 
-func createTransactionTemplate(c *Client, project Project) TransactionTemplate {
+func createTransactionTemplate(t *testing.T, c *Client, project Project) TransactionTemplate {
 	var resp CreateTransactionTemplateResponse
 
-	c.MustPost(
+	err := c.Post(
 		MutationCreateTransactionTemplate,
 		&resp,
 		client.Var("projectId", project.ID),
@@ -2330,14 +2375,15 @@ func createTransactionTemplate(c *Client, project Project) TransactionTemplate {
 		client.Var("script", "bar"),
 		client.AddCookie(c.SessionCookie()),
 	)
+	require.NoError(t, err)
 
 	return resp.CreateTransactionTemplate
 }
 
-func createScriptTemplate(c *Client, project Project) string {
+func createScriptTemplate(t *testing.T, c *Client, project Project) string {
 	var resp CreateScriptTemplateResponse
 
-	c.MustPost(
+	err := c.Post(
 		MutationCreateScriptTemplate,
 		&resp,
 		client.Var("projectId", project.ID),
@@ -2345,6 +2391,7 @@ func createScriptTemplate(c *Client, project Project) string {
 		client.Var("script", "bar"),
 		client.AddCookie(c.SessionCookie()),
 	)
+	require.NoError(t, err)
 
 	return resp.CreateScriptTemplate.ID
 }

--- a/playground_test.go
+++ b/playground_test.go
@@ -2291,12 +2291,7 @@ func newClientWithResolver(resolver *playground.Resolver) *Client {
 	router.Use(httpcontext.Middleware())
 	router.Use(legacyauth.MockProjectSessions())
 
-	router.Handle(
-		"/",
-		handler.GraphQL(
-			playground.NewExecutableSchema(playground.Config{Resolvers: resolver}),
-		),
-	)
+	router.Handle("/", playground.GraphQLHandler(resolver))
 
 	return &Client{
 		client:   client.New(router),

--- a/resolver.go
+++ b/resolver.go
@@ -1,3 +1,21 @@
+/*
+ * Flow Playground
+ *
+ * Copyright 2019-2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package playground
 
 import (

--- a/server/server.go
+++ b/server/server.go
@@ -21,14 +21,15 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/dapperlabs/flow-playground-api/controller"
-	"github.com/go-chi/render"
-	"github.com/rs/zerolog"
-
 	"log"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/go-chi/render"
+	"github.com/rs/zerolog"
+
+	"github.com/dapperlabs/flow-playground-api/controller"
 
 	"github.com/99designs/gqlgen-contrib/prometheus"
 	"github.com/99designs/gqlgen/handler"
@@ -152,12 +153,15 @@ func main() {
 		r.Use(httpcontext.Middleware())
 		r.Use(sessions.Middleware(cookieStore))
 
-		r.Handle("/", handler.GraphQL(
-			playground.NewExecutableSchema(playground.Config{Resolvers: resolver}),
-			handler.RequestMiddleware(errors.Middleware(entry)),
-			handler.RequestMiddleware(prometheus.RequestMiddleware()),
-			handler.ResolverMiddleware(prometheus.ResolverMiddleware()),
-		))
+		r.Handle(
+			"/",
+			playground.GraphQLHandler(
+				resolver,
+				handler.RequestMiddleware(errors.Middleware(entry)),
+				handler.RequestMiddleware(prometheus.RequestMiddleware()),
+				handler.ResolverMiddleware(prometheus.ResolverMiddleware()),
+			),
+		)
 	})
 
 	embedsHandler := controller.NewEmbedsHandler(store, conf.PlaygroundBaseURL)


### PR DESCRIPTION
## Description

Debugging errors is quite difficult right now: When the API panics, it only reports a "internal server error" to the client.

Usually we do this for security reasons, so we don't leak information about the BE code, but given that this is the Playground and the code is open-source, I think we can simply include the stack trace.

Also:
- Improve the tests: Don't panic when a request fails, simply require it to succeed
- Fix the license header script and add the missing license header

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

