### PR TITLE
Increase number of accounts to 5

### DIFF
--- a/playground_test.go
+++ b/playground_test.go
@@ -981,10 +981,10 @@ func TestTransactionExecutions(t *testing.T) {
 
 		eventA := respA.CreateTransactionExecution.Events[0]
 
-		// first account should have address 0x05
+		// first account should have address 0x06
 		assert.Equal(t, "flow.AccountCreated", eventA.Type)
 		assert.JSONEq(t,
-			`{"type":"Address","value":"0x0000000000000005"}`,
+			`{"type":"Address","value":"0x0000000000000006"}`,
 			eventA.Values[0],
 		)
 
@@ -1004,10 +1004,10 @@ func TestTransactionExecutions(t *testing.T) {
 
 		eventB := respB.CreateTransactionExecution.Events[0]
 
-		// second account should have address 0x06
+		// second account should have address 0x07
 		assert.Equal(t, "flow.AccountCreated", eventB.Type)
 		assert.JSONEq(t,
-			`{"type":"Address","value":"0x0000000000000006"}`,
+			`{"type":"Address","value":"0x0000000000000007"}`,
 			eventB.Values[0],
 		)
 	})
@@ -1041,10 +1041,10 @@ func TestTransactionExecutions(t *testing.T) {
 
 		eventA := respA.CreateTransactionExecution.Events[0]
 
-		// first account should have address 0x05
+		// first account should have address 0x06
 		assert.Equal(t, "flow.AccountCreated", eventA.Type)
 		assert.JSONEq(t,
-			`{"type":"Address","value":"0x0000000000000005"}`,
+			`{"type":"Address","value":"0x0000000000000006"}`,
 			eventA.Values[0],
 		)
 
@@ -1066,10 +1066,10 @@ func TestTransactionExecutions(t *testing.T) {
 
 		eventB := respB.CreateTransactionExecution.Events[0]
 
-		// second account should have address 0x06
+		// second account should have address 0x07
 		assert.Equal(t, "flow.AccountCreated", eventB.Type)
 		assert.JSONEq(t,
-			`{"type":"Address","value":"0x0000000000000006"}`,
+			`{"type":"Address","value":"0x0000000000000007"}`,
 			eventB.Values[0],
 		)
 	})

--- a/resolver.go
+++ b/resolver.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dapperlabs/flow-playground-api/storage"
 )
 
-const MaxAccounts = 4
+const MaxAccounts = 5
 
 type Resolver struct {
 	version            *semver.Version


### PR DESCRIPTION
Kitty Items requires 5 contracts. It would be nice to be able to test out Kitty Items Cadence in the Playground.
