### PR TITLE
Playground Feature: Multiple contracts per account for Flipfest issue 21

### DIFF
--- a/controller/embeds.go
+++ b/controller/embeds.go
@@ -130,8 +130,9 @@ func (e *EmbedsHandler) GetCode(id model.ProjectChildID, scriptType string) (str
 		return e.GetScriptTemplate(id)
 	case "transaction":
 		return e.GetTransactionTemplate(id)
-	case "account":
-		return e.GetAccountTemplate(id)
+	//soe to-do confirm that this is not need anymore
+	//case "account":
+	//return e.GetAccountTemplate(id)
 	default:
 		return "", fmt.Errorf("invalid script type: %s", scriptType)
 	}
@@ -160,6 +161,8 @@ func (e *EmbedsHandler) GetTransactionTemplate(id model.ProjectChildID) (string,
 	return tmpl.Script, nil
 }
 
+//soe to-do confirm that this is not need anymore
+/*
 func (e *EmbedsHandler) GetAccountTemplate(id model.ProjectChildID) (string, error) {
 	var tmpl model.InternalAccount
 
@@ -169,7 +172,7 @@ func (e *EmbedsHandler) GetAccountTemplate(id model.ProjectChildID) (string, err
 	}
 
 	return tmpl.DraftCode, nil
-}
+}*/
 
 func getUUID(paramName string, r *http.Request) (id uuid.UUID, err error) {
 	rawID, err := getURLParam(paramName, r)

--- a/controller/embeds.go
+++ b/controller/embeds.go
@@ -168,7 +168,7 @@ func (e *EmbedsHandler) GetContractTemplate(id model.ProjectChildID) (string, er
 		return "", err
 	}
 
-	return tmpl.Script, nil
+	return tmpl.Code, nil
 }
 
 func getUUID(paramName string, r *http.Request) (id uuid.UUID, err error) {

--- a/controller/embeds.go
+++ b/controller/embeds.go
@@ -130,9 +130,8 @@ func (e *EmbedsHandler) GetCode(id model.ProjectChildID, scriptType string) (str
 		return e.GetScriptTemplate(id)
 	case "transaction":
 		return e.GetTransactionTemplate(id)
-	//soe to-do confirm that this is not need anymore
-	//case "account":
-	//return e.GetAccountTemplate(id)
+	case "contract":
+		return e.GetContractTemplate(id)
 	default:
 		return "", fmt.Errorf("invalid script type: %s", scriptType)
 	}
@@ -161,18 +160,16 @@ func (e *EmbedsHandler) GetTransactionTemplate(id model.ProjectChildID) (string,
 	return tmpl.Script, nil
 }
 
-//soe to-do confirm that this is not need anymore
-/*
-func (e *EmbedsHandler) GetAccountTemplate(id model.ProjectChildID) (string, error) {
-	var tmpl model.InternalAccount
+func (e *EmbedsHandler) GetContractTemplate(id model.ProjectChildID) (string, error) {
+	var tmpl model.Contract
 
-	err := e.store.GetAccount(id, &tmpl)
+	err := e.store.GetContract(id, &tmpl)
 	if err != nil {
 		return "", err
 	}
 
-	return tmpl.DraftCode, nil
-}*/
+	return tmpl.Script, nil
+}
 
 func getUUID(paramName string, r *http.Request) (id uuid.UUID, err error) {
 	rawID, err := getURLParam(paramName, r)

--- a/controller/embeds_test.go
+++ b/controller/embeds_test.go
@@ -117,13 +117,14 @@ func TestEmbedsHandler_ServeHTTP(t *testing.T) {
 	}
 
 	accounts := make([]*model.InternalAccount, 0)
+	cons := make([]*model.Contract, 0)
 	deltas := make([]delta.Delta, 0)
 	ttpls := make([]*model.TransactionTemplate, 0)
 	stpls := make([]*model.ScriptTemplate, 0)
 
 	internalProj.UserID = user.ID
 
-	projErr := store.CreateProject(internalProj, deltas, accounts, ttpls, stpls)
+	projErr := store.CreateProject(internalProj, deltas, accounts, cons, ttpls, stpls)
 	require.NoError(t, projErr)
 
 	script := `

--- a/controller/projects.go
+++ b/controller/projects.go
@@ -72,6 +72,25 @@ func (p *Projects) Create(user *model.User, input model.NewProject) (*model.Inte
 		return nil, err
 	}
 
+	cons := make([]*model.Contract, len(input.Contracts))
+
+	for i, con := range input.Contracts {
+
+		con := &model.Contract{
+			ProjectChildID: model.ProjectChildID{
+				ID:        uuid.New(),
+				ProjectID: proj.ID,
+			},
+			// local account index is swapped with actual account id
+			AccountID: accounts[con.Index].ID,
+			Title:     con.Title,
+			Script:    con.Script,
+			Index:     con.Index,
+		}
+
+		cons[i] = con
+	}
+
 	ttpls := make([]*model.TransactionTemplate, len(input.TransactionTemplates))
 
 	for i, tpl := range input.TransactionTemplates {
@@ -104,7 +123,7 @@ func (p *Projects) Create(user *model.User, input model.NewProject) (*model.Inte
 
 	proj.UserID = user.ID
 
-	err = p.store.CreateProject(proj, deltas, accounts, ttpls, stpls)
+	err = p.store.CreateProject(proj, deltas, accounts, cons, ttpls, stpls)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create project")
 	}

--- a/controller/projects.go
+++ b/controller/projects.go
@@ -81,9 +81,9 @@ func (p *Projects) Create(user *model.User, input model.NewProject) (*model.Inte
 				ID:        uuid.New(),
 				ProjectID: proj.ID,
 			},
-			Title:  con.Title,
-			Script: con.Script,
-			Index:  con.Index,
+			Title:        con.Title,
+			Code:         con.Code,
+			AccountIndex: con.AccountIndex,
 		}
 
 		cons[i] = con

--- a/controller/projects.go
+++ b/controller/projects.go
@@ -81,11 +81,9 @@ func (p *Projects) Create(user *model.User, input model.NewProject) (*model.Inte
 				ID:        uuid.New(),
 				ProjectID: proj.ID,
 			},
-			// local account index is swapped with actual account id
-			AccountID: accounts[con.Index].ID,
-			Title:     con.Title,
-			Script:    con.Script,
-			Index:     con.Index,
+			Title:  con.Title,
+			Script: con.Script,
+			Index:  con.Index,
 		}
 
 		cons[i] = con

--- a/controller/projects.go
+++ b/controller/projects.go
@@ -153,9 +153,9 @@ func (p *Projects) createInitialAccounts(
 
 		account.SetState(make(model.AccountState))
 
-		if i < len(initialContracts) {
+		/*if i < len(initialContracts) {
 			account.DraftCode = initialContracts[i]
-		}
+		}*/
 
 		accounts[i] = &account
 	}

--- a/generated.go
+++ b/generated.go
@@ -1066,6 +1066,7 @@ input UpdateContract {
   id: UUID!
   title: String
   projectId: UUID!
+  accountId: UUID
   index: Int
   script: String
   deployedScript: String
@@ -6025,6 +6026,12 @@ func (ec *executionContext) unmarshalInputUpdateContract(ctx context.Context, ob
 		case "projectId":
 			var err error
 			it.ProjectID, err = ec.unmarshalNUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "accountId":
+			var err error
+			it.AccountID, err = ec.unmarshalOUUID2ᚖgithubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/generated.go
+++ b/generated.go
@@ -57,7 +57,6 @@ type ComplexityRoot struct {
 	}
 
 	Contract struct {
-		AccountID      func(childComplexity int) int
 		DeployedScript func(childComplexity int) int
 		ID             func(childComplexity int) int
 		Index          func(childComplexity int) int
@@ -256,13 +255,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Account.State(childComplexity), true
-
-	case "Contract.accountId":
-		if e.complexity.Contract.AccountID == nil {
-			break
-		}
-
-		return e.complexity.Contract.AccountID(childComplexity), true
 
 	case "Contract.deployedScript":
 		if e.complexity.Contract.DeployedScript == nil {
@@ -948,7 +940,6 @@ type Account {
 
 type Contract {
   id: UUID!
-  accountId: UUID
   index: Int!
   title: String!
   script: String!
@@ -1066,7 +1057,6 @@ input UpdateContract {
   id: UUID!
   title: String
   projectId: UUID!
-  accountId: UUID
   index: Int
   script: String
   deployedScript: String
@@ -1769,40 +1759,6 @@ func (ec *executionContext) _Contract_id(ctx context.Context, field graphql.Coll
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
 	return ec.marshalNUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Contract_accountId(ctx context.Context, field graphql.CollectedField, obj *model.Contract) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "Contract",
-		Field:    field,
-		Args:     nil,
-		IsMethod: false,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.AccountID, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(uuid.UUID)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Contract_index(ctx context.Context, field graphql.CollectedField, obj *model.Contract) (ret graphql.Marshaler) {
@@ -6029,12 +5985,6 @@ func (ec *executionContext) unmarshalInputUpdateContract(ctx context.Context, ob
 			if err != nil {
 				return it, err
 			}
-		case "accountId":
-			var err error
-			it.AccountID, err = ec.unmarshalOUUID2ᚖgithubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, v)
-			if err != nil {
-				return it, err
-			}
 		case "index":
 			var err error
 			it.Index, err = ec.unmarshalOInt2ᚖint(ctx, v)
@@ -6249,8 +6199,6 @@ func (ec *executionContext) _Contract(ctx context.Context, sel ast.SelectionSet,
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
-		case "accountId":
-			out.Values[i] = ec._Contract_accountId(ctx, field, obj)
 		case "index":
 			out.Values[i] = ec._Contract_index(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/generated.go
+++ b/generated.go
@@ -55,11 +55,11 @@ type ComplexityRoot struct {
 	}
 
 	Contract struct {
-		DeployedScript func(childComplexity int) int
-		ID             func(childComplexity int) int
-		Index          func(childComplexity int) int
-		Script         func(childComplexity int) int
-		Title          func(childComplexity int) int
+		AccountIndex func(childComplexity int) int
+		Code         func(childComplexity int) int
+		DeployedCode func(childComplexity int) int
+		ID           func(childComplexity int) int
+		Title        func(childComplexity int) int
 	}
 
 	Event struct {
@@ -242,12 +242,26 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Account.State(childComplexity), true
 
-	case "Contract.deployedScript":
-		if e.complexity.Contract.DeployedScript == nil {
+	case "Contract.accountIndex":
+		if e.complexity.Contract.AccountIndex == nil {
 			break
 		}
 
-		return e.complexity.Contract.DeployedScript(childComplexity), true
+		return e.complexity.Contract.AccountIndex(childComplexity), true
+
+	case "Contract.code":
+		if e.complexity.Contract.Code == nil {
+			break
+		}
+
+		return e.complexity.Contract.Code(childComplexity), true
+
+	case "Contract.deployedCode":
+		if e.complexity.Contract.DeployedCode == nil {
+			break
+		}
+
+		return e.complexity.Contract.DeployedCode(childComplexity), true
 
 	case "Contract.id":
 		if e.complexity.Contract.ID == nil {
@@ -255,20 +269,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Contract.ID(childComplexity), true
-
-	case "Contract.index":
-		if e.complexity.Contract.Index == nil {
-			break
-		}
-
-		return e.complexity.Contract.Index(childComplexity), true
-
-	case "Contract.script":
-		if e.complexity.Contract.Script == nil {
-			break
-		}
-
-		return e.complexity.Contract.Script(childComplexity), true
 
 	case "Contract.title":
 		if e.complexity.Contract.Title == nil {
@@ -936,10 +936,10 @@ type Account {
 
 type Contract {
   id: UUID!
-  index: Int!
+  accountIndex: Int!
   title: String!
-  script: String!
-  deployedScript: String
+  code: String!
+  deployedCode: String
 }
 
 type ProgramError {
@@ -1013,9 +1013,9 @@ input NewProject {
 }
 
 input NewProjectContract {
-  index: Int!
+  accountIndex: Int!
   title: String!
-  script: String!
+  code: String!
 }
 
 input NewProjectTransactionTemplate {
@@ -1042,18 +1042,18 @@ input UpdateAccount {
 
 input NewContract {
   projectId: UUID!
-  index: Int!
+  accountIndex: Int!
   title: String!
-  script: String!
+  code: String!
 }
 
 input UpdateContract {
   id: UUID!
   title: String
   projectId: UUID!
-  index: Int
-  script: String
-  deployedScript: String
+  accountIndex: Int
+  code: String
+  deployedCode: String
 }
 
 input DeployContract {
@@ -1061,9 +1061,9 @@ input DeployContract {
   title: String
   projectId: UUID!
   accountId: UUID!
-  index: Int
-  script: String
-  deployedScript: String
+  accountIndex: Int
+  code: String
+  deployedCode: String
 }
 
 input NewTransactionTemplate {
@@ -1706,7 +1706,7 @@ func (ec *executionContext) _Contract_id(ctx context.Context, field graphql.Coll
 	return ec.marshalNUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _Contract_index(ctx context.Context, field graphql.CollectedField, obj *model.Contract) (ret graphql.Marshaler) {
+func (ec *executionContext) _Contract_accountIndex(ctx context.Context, field graphql.CollectedField, obj *model.Contract) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
 		if r := recover(); r != nil {
@@ -1725,7 +1725,7 @@ func (ec *executionContext) _Contract_index(ctx context.Context, field graphql.C
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Index, nil
+		return obj.AccountIndex, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -1780,7 +1780,7 @@ func (ec *executionContext) _Contract_title(ctx context.Context, field graphql.C
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _Contract_script(ctx context.Context, field graphql.CollectedField, obj *model.Contract) (ret graphql.Marshaler) {
+func (ec *executionContext) _Contract_code(ctx context.Context, field graphql.CollectedField, obj *model.Contract) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
 		if r := recover(); r != nil {
@@ -1799,7 +1799,7 @@ func (ec *executionContext) _Contract_script(ctx context.Context, field graphql.
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Script, nil
+		return obj.Code, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -1817,7 +1817,7 @@ func (ec *executionContext) _Contract_script(ctx context.Context, field graphql.
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _Contract_deployedScript(ctx context.Context, field graphql.CollectedField, obj *model.Contract) (ret graphql.Marshaler) {
+func (ec *executionContext) _Contract_deployedCode(ctx context.Context, field graphql.CollectedField, obj *model.Contract) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
 		if r := recover(); r != nil {
@@ -1836,7 +1836,7 @@ func (ec *executionContext) _Contract_deployedScript(ctx context.Context, field 
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.DeployedScript, nil
+		return obj.DeployedCode, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -5644,21 +5644,21 @@ func (ec *executionContext) unmarshalInputDeployContract(ctx context.Context, ob
 			if err != nil {
 				return it, err
 			}
-		case "index":
+		case "accountIndex":
 			var err error
-			it.Index, err = ec.unmarshalOInt2ᚖint(ctx, v)
+			it.AccountIndex, err = ec.unmarshalOInt2ᚖint(ctx, v)
 			if err != nil {
 				return it, err
 			}
-		case "script":
+		case "code":
 			var err error
-			it.Script, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			it.Code, err = ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-		case "deployedScript":
+		case "deployedCode":
 			var err error
-			it.DeployedScript, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			it.DeployedCode, err = ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -5680,9 +5680,9 @@ func (ec *executionContext) unmarshalInputNewContract(ctx context.Context, obj i
 			if err != nil {
 				return it, err
 			}
-		case "index":
+		case "accountIndex":
 			var err error
-			it.Index, err = ec.unmarshalNInt2int(ctx, v)
+			it.AccountIndex, err = ec.unmarshalNInt2int(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -5692,9 +5692,9 @@ func (ec *executionContext) unmarshalInputNewContract(ctx context.Context, obj i
 			if err != nil {
 				return it, err
 			}
-		case "script":
+		case "code":
 			var err error
-			it.Script, err = ec.unmarshalNString2string(ctx, v)
+			it.Code, err = ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -5764,9 +5764,9 @@ func (ec *executionContext) unmarshalInputNewProjectContract(ctx context.Context
 
 	for k, v := range asMap {
 		switch k {
-		case "index":
+		case "accountIndex":
 			var err error
-			it.Index, err = ec.unmarshalNInt2int(ctx, v)
+			it.AccountIndex, err = ec.unmarshalNInt2int(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -5776,9 +5776,9 @@ func (ec *executionContext) unmarshalInputNewProjectContract(ctx context.Context
 			if err != nil {
 				return it, err
 			}
-		case "script":
+		case "code":
 			var err error
-			it.Script, err = ec.unmarshalNString2string(ctx, v)
+			it.Code, err = ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -6016,21 +6016,21 @@ func (ec *executionContext) unmarshalInputUpdateContract(ctx context.Context, ob
 			if err != nil {
 				return it, err
 			}
-		case "index":
+		case "accountIndex":
 			var err error
-			it.Index, err = ec.unmarshalOInt2ᚖint(ctx, v)
+			it.AccountIndex, err = ec.unmarshalOInt2ᚖint(ctx, v)
 			if err != nil {
 				return it, err
 			}
-		case "script":
+		case "code":
 			var err error
-			it.Script, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			it.Code, err = ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-		case "deployedScript":
+		case "deployedCode":
 			var err error
-			it.DeployedScript, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			it.DeployedCode, err = ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -6220,8 +6220,8 @@ func (ec *executionContext) _Contract(ctx context.Context, sel ast.SelectionSet,
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
-		case "index":
-			out.Values[i] = ec._Contract_index(ctx, field, obj)
+		case "accountIndex":
+			out.Values[i] = ec._Contract_accountIndex(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
@@ -6230,13 +6230,13 @@ func (ec *executionContext) _Contract(ctx context.Context, sel ast.SelectionSet,
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
-		case "script":
-			out.Values[i] = ec._Contract_script(ctx, field, obj)
+		case "code":
+			out.Values[i] = ec._Contract_code(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
-		case "deployedScript":
-			out.Values[i] = ec._Contract_deployedScript(ctx, field, obj)
+		case "deployedCode":
+			out.Values[i] = ec._Contract_deployedCode(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/generated.go
+++ b/generated.go
@@ -56,20 +56,32 @@ type ComplexityRoot struct {
 		State             func(childComplexity int) int
 	}
 
+	Contract struct {
+		AccountID      func(childComplexity int) int
+		DeployedScript func(childComplexity int) int
+		ID             func(childComplexity int) int
+		Index          func(childComplexity int) int
+		Script         func(childComplexity int) int
+		Title          func(childComplexity int) int
+	}
+
 	Event struct {
 		Type   func(childComplexity int) int
 		Values func(childComplexity int) int
 	}
 
 	Mutation struct {
+		CreateContract             func(childComplexity int, input model.NewContract) int
 		CreateProject              func(childComplexity int, input model.NewProject) int
 		CreateScriptExecution      func(childComplexity int, input model.NewScriptExecution) int
 		CreateScriptTemplate       func(childComplexity int, input model.NewScriptTemplate) int
 		CreateTransactionExecution func(childComplexity int, input model.NewTransactionExecution) int
 		CreateTransactionTemplate  func(childComplexity int, input model.NewTransactionTemplate) int
+		DeleteContract             func(childComplexity int, id uuid.UUID, projectID uuid.UUID) int
 		DeleteScriptTemplate       func(childComplexity int, id uuid.UUID, projectID uuid.UUID) int
 		DeleteTransactionTemplate  func(childComplexity int, id uuid.UUID, projectID uuid.UUID) int
 		UpdateAccount              func(childComplexity int, input model.UpdateAccount) int
+		UpdateContract             func(childComplexity int, input model.UpdateContract) int
 		UpdateProject              func(childComplexity int, input model.UpdateProject) int
 		UpdateScriptTemplate       func(childComplexity int, input model.UpdateScriptTemplate) int
 		UpdateTransactionTemplate  func(childComplexity int, input model.UpdateTransactionTemplate) int
@@ -94,6 +106,7 @@ type ComplexityRoot struct {
 
 	Project struct {
 		Accounts              func(childComplexity int) int
+		Contracts             func(childComplexity int) int
 		ID                    func(childComplexity int) int
 		Mutable               func(childComplexity int) int
 		ParentID              func(childComplexity int) int
@@ -110,6 +123,7 @@ type ComplexityRoot struct {
 
 	Query struct {
 		Account             func(childComplexity int, id uuid.UUID, projectID uuid.UUID) int
+		Contract            func(childComplexity int, id uuid.UUID, projectID uuid.UUID) int
 		PlaygroundInfo      func(childComplexity int) int
 		Project             func(childComplexity int, id uuid.UUID) int
 		ScriptTemplate      func(childComplexity int, id uuid.UUID, projectID uuid.UUID) int
@@ -154,6 +168,9 @@ type MutationResolver interface {
 	CreateProject(ctx context.Context, input model.NewProject) (*model.Project, error)
 	UpdateProject(ctx context.Context, input model.UpdateProject) (*model.Project, error)
 	UpdateAccount(ctx context.Context, input model.UpdateAccount) (*model.Account, error)
+	CreateContract(ctx context.Context, input model.NewContract) (*model.Contract, error)
+	UpdateContract(ctx context.Context, input model.UpdateContract) (*model.Contract, error)
+	DeleteContract(ctx context.Context, id uuid.UUID, projectID uuid.UUID) (uuid.UUID, error)
 	CreateTransactionTemplate(ctx context.Context, input model.NewTransactionTemplate) (*model.TransactionTemplate, error)
 	UpdateTransactionTemplate(ctx context.Context, input model.UpdateTransactionTemplate) (*model.TransactionTemplate, error)
 	DeleteTransactionTemplate(ctx context.Context, id uuid.UUID, projectID uuid.UUID) (uuid.UUID, error)
@@ -165,6 +182,7 @@ type MutationResolver interface {
 }
 type ProjectResolver interface {
 	Accounts(ctx context.Context, obj *model.Project) ([]*model.Account, error)
+	Contracts(ctx context.Context, obj *model.Project) ([]*model.Contract, error)
 	TransactionTemplates(ctx context.Context, obj *model.Project) ([]*model.TransactionTemplate, error)
 	TransactionExecutions(ctx context.Context, obj *model.Project) ([]*model.TransactionExecution, error)
 	ScriptTemplates(ctx context.Context, obj *model.Project) ([]*model.ScriptTemplate, error)
@@ -174,6 +192,7 @@ type QueryResolver interface {
 	PlaygroundInfo(ctx context.Context) (*model.PlaygroundInfo, error)
 	Project(ctx context.Context, id uuid.UUID) (*model.Project, error)
 	Account(ctx context.Context, id uuid.UUID, projectID uuid.UUID) (*model.Account, error)
+	Contract(ctx context.Context, id uuid.UUID, projectID uuid.UUID) (*model.Contract, error)
 	TransactionTemplate(ctx context.Context, id uuid.UUID, projectID uuid.UUID) (*model.TransactionTemplate, error)
 	ScriptTemplate(ctx context.Context, id uuid.UUID, projectID uuid.UUID) (*model.ScriptTemplate, error)
 }
@@ -238,6 +257,48 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Account.State(childComplexity), true
 
+	case "Contract.accountId":
+		if e.complexity.Contract.AccountID == nil {
+			break
+		}
+
+		return e.complexity.Contract.AccountID(childComplexity), true
+
+	case "Contract.deployedScript":
+		if e.complexity.Contract.DeployedScript == nil {
+			break
+		}
+
+		return e.complexity.Contract.DeployedScript(childComplexity), true
+
+	case "Contract.id":
+		if e.complexity.Contract.ID == nil {
+			break
+		}
+
+		return e.complexity.Contract.ID(childComplexity), true
+
+	case "Contract.index":
+		if e.complexity.Contract.Index == nil {
+			break
+		}
+
+		return e.complexity.Contract.Index(childComplexity), true
+
+	case "Contract.script":
+		if e.complexity.Contract.Script == nil {
+			break
+		}
+
+		return e.complexity.Contract.Script(childComplexity), true
+
+	case "Contract.title":
+		if e.complexity.Contract.Title == nil {
+			break
+		}
+
+		return e.complexity.Contract.Title(childComplexity), true
+
 	case "Event.type":
 		if e.complexity.Event.Type == nil {
 			break
@@ -251,6 +312,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Event.Values(childComplexity), true
+
+	case "Mutation.createContract":
+		if e.complexity.Mutation.CreateContract == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_createContract_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreateContract(childComplexity, args["input"].(model.NewContract)), true
 
 	case "Mutation.createProject":
 		if e.complexity.Mutation.CreateProject == nil {
@@ -312,6 +385,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.CreateTransactionTemplate(childComplexity, args["input"].(model.NewTransactionTemplate)), true
 
+	case "Mutation.deleteContract":
+		if e.complexity.Mutation.DeleteContract == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_deleteContract_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteContract(childComplexity, args["id"].(uuid.UUID), args["projectId"].(uuid.UUID)), true
+
 	case "Mutation.deleteScriptTemplate":
 		if e.complexity.Mutation.DeleteScriptTemplate == nil {
 			break
@@ -347,6 +432,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.UpdateAccount(childComplexity, args["input"].(model.UpdateAccount)), true
+
+	case "Mutation.updateContract":
+		if e.complexity.Mutation.UpdateContract == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_updateContract_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UpdateContract(childComplexity, args["input"].(model.UpdateContract)), true
 
 	case "Mutation.updateProject":
 		if e.complexity.Mutation.UpdateProject == nil {
@@ -447,6 +544,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Project.Accounts(childComplexity), true
 
+	case "Project.contracts":
+		if e.complexity.Project.Contracts == nil {
+			break
+		}
+
+		return e.complexity.Project.Contracts(childComplexity), true
+
 	case "Project.id":
 		if e.complexity.Project.ID == nil {
 			break
@@ -542,6 +646,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.Account(childComplexity, args["id"].(uuid.UUID), args["projectId"].(uuid.UUID)), true
+
+	case "Query.contract":
+		if e.complexity.Query.Contract == nil {
+			break
+		}
+
+		args, err := ec.field_Query_contract_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.Contract(childComplexity, args["id"].(uuid.UUID), args["projectId"].(uuid.UUID)), true
 
 	case "Query.playgroundInfo":
 		if e.complexity.Query.PlaygroundInfo == nil {
@@ -814,6 +930,7 @@ type Project {
   persist: Boolean
   mutable: Boolean
   accounts: [Account!]
+  contracts: [Contract!]
   transactionTemplates: [TransactionTemplate!]
   transactionExecutions: [TransactionExecution!]
   scriptTemplates: [ScriptTemplate!]
@@ -827,6 +944,15 @@ type Account {
   deployedCode: String!
   deployedContracts: [String!]!
   state: String!
+}
+
+type Contract {
+  id: UUID!
+  accountId: UUID
+  index: Int!
+  title: String!
+  script: String!
+  deployedScript: String
 }
 
 type ProgramError {
@@ -884,6 +1010,7 @@ type Query {
   project(id: UUID!): Project!
 
   account(id: UUID!, projectId: UUID!): Account!
+  contract(id: UUID!, projectId: UUID!): Contract!
   transactionTemplate(id: UUID!, projectId: UUID!): TransactionTemplate!
   scriptTemplate(id: UUID!, projectId: UUID!): ScriptTemplate!
 }
@@ -893,8 +1020,15 @@ input NewProject {
   title: String!
   seed: Int!
   accounts: [String!]
+  contracts: [NewProjectContract!]
   transactionTemplates: [NewProjectTransactionTemplate!]
   scriptTemplates: [NewProjectScriptTemplate!]
+}
+
+input NewProjectContract {
+  index: Int!
+  title: String!
+  script: String!
 }
 
 input NewProjectTransactionTemplate {
@@ -916,8 +1050,25 @@ input UpdateProject {
 input UpdateAccount {
   id: UUID!
   projectId: UUID!
+  contractId: UUID
   draftCode: String
   deployedCode: String
+}
+
+input NewContract {
+  projectId: UUID!
+  index: Int!
+  title: String!
+  script: String!
+}
+
+input UpdateContract {
+  id: UUID!
+  title: String
+  projectId: UUID!
+  index: Int
+  script: String
+  deployedScript: String
 }
 
 input NewTransactionTemplate {
@@ -967,6 +1118,10 @@ type Mutation {
 
   updateAccount(input: UpdateAccount!): Account!
 
+  createContract(input: NewContract!): Contract!
+  updateContract(input: UpdateContract!): Contract!
+  deleteContract(id: UUID!, projectId: UUID!): UUID!
+
   createTransactionTemplate(input: NewTransactionTemplate!): TransactionTemplate!
   updateTransactionTemplate(input: UpdateTransactionTemplate!): TransactionTemplate!
   deleteTransactionTemplate(id: UUID!, projectId: UUID!): UUID!
@@ -977,13 +1132,26 @@ type Mutation {
   deleteScriptTemplate(id: UUID!, projectId: UUID!): UUID!
   createScriptExecution(input: NewScriptExecution!): ScriptExecution!
 }
-
 `},
 )
 
 // endregion ************************** generated!.gotpl **************************
 
 // region    ***************************** args.gotpl *****************************
+
+func (ec *executionContext) field_Mutation_createContract_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 model.NewContract
+	if tmp, ok := rawArgs["input"]; ok {
+		arg0, err = ec.unmarshalNNewContract2githubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐNewContract(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
 
 func (ec *executionContext) field_Mutation_createProject_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
@@ -1055,6 +1223,28 @@ func (ec *executionContext) field_Mutation_createTransactionTemplate_args(ctx co
 	return args, nil
 }
 
+func (ec *executionContext) field_Mutation_deleteContract_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 uuid.UUID
+	if tmp, ok := rawArgs["id"]; ok {
+		arg0, err = ec.unmarshalNUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["id"] = arg0
+	var arg1 uuid.UUID
+	if tmp, ok := rawArgs["projectId"]; ok {
+		arg1, err = ec.unmarshalNUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["projectId"] = arg1
+	return args, nil
+}
+
 func (ec *executionContext) field_Mutation_deleteScriptTemplate_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -1105,6 +1295,20 @@ func (ec *executionContext) field_Mutation_updateAccount_args(ctx context.Contex
 	var arg0 model.UpdateAccount
 	if tmp, ok := rawArgs["input"]; ok {
 		arg0, err = ec.unmarshalNUpdateAccount2githubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐUpdateAccount(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_updateContract_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 model.UpdateContract
+	if tmp, ok := rawArgs["input"]; ok {
+		arg0, err = ec.unmarshalNUpdateContract2githubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐUpdateContract(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -1170,6 +1374,28 @@ func (ec *executionContext) field_Query___type_args(ctx context.Context, rawArgs
 }
 
 func (ec *executionContext) field_Query_account_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 uuid.UUID
+	if tmp, ok := rawArgs["id"]; ok {
+		arg0, err = ec.unmarshalNUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["id"] = arg0
+	var arg1 uuid.UUID
+	if tmp, ok := rawArgs["projectId"]; ok {
+		arg1, err = ec.unmarshalNUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["projectId"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_contract_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
 	var arg0 uuid.UUID
@@ -1507,6 +1733,222 @@ func (ec *executionContext) _Account_state(ctx context.Context, field graphql.Co
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Contract_id(ctx context.Context, field graphql.CollectedField, obj *model.Contract) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Contract",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(uuid.UUID)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Contract_accountId(ctx context.Context, field graphql.CollectedField, obj *model.Contract) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Contract",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AccountID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(uuid.UUID)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Contract_index(ctx context.Context, field graphql.CollectedField, obj *model.Contract) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Contract",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Index, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Contract_title(ctx context.Context, field graphql.CollectedField, obj *model.Contract) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Contract",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Title, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Contract_script(ctx context.Context, field graphql.CollectedField, obj *model.Contract) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Contract",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Script, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Contract_deployedScript(ctx context.Context, field graphql.CollectedField, obj *model.Contract) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Contract",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DeployedScript, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Event_type(ctx context.Context, field graphql.CollectedField, obj *model.Event) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
@@ -1711,6 +2153,138 @@ func (ec *executionContext) _Mutation_updateAccount(ctx context.Context, field g
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
 	return ec.marshalNAccount2ᚖgithubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐAccount(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_createContract(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Mutation",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_createContract_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateContract(rctx, args["input"].(model.NewContract))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Contract)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNContract2ᚖgithubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐContract(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_updateContract(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Mutation",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_updateContract_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UpdateContract(rctx, args["input"].(model.UpdateContract))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Contract)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNContract2ᚖgithubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐContract(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_deleteContract(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Mutation",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_deleteContract_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteContract(rctx, args["id"].(uuid.UUID), args["projectId"].(uuid.UUID))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(uuid.UUID)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Mutation_createTransactionTemplate(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -2676,6 +3250,40 @@ func (ec *executionContext) _Project_accounts(ctx context.Context, field graphql
 	return ec.marshalOAccount2ᚕᚖgithubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐAccountᚄ(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Project_contracts(ctx context.Context, field graphql.CollectedField, obj *model.Project) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Project",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Project().Contracts(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.Contract)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOContract2ᚕᚖgithubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐContractᚄ(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Project_transactionTemplates(ctx context.Context, field graphql.CollectedField, obj *model.Project) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
@@ -2935,6 +3543,50 @@ func (ec *executionContext) _Query_account(ctx context.Context, field graphql.Co
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
 	return ec.marshalNAccount2ᚖgithubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐAccount(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Query_contract(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Query",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Query_contract_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Contract(rctx, args["id"].(uuid.UUID), args["projectId"].(uuid.UUID))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Contract)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNContract2ᚖgithubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐContract(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_transactionTemplate(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -5016,6 +5668,42 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 
 // region    **************************** input.gotpl *****************************
 
+func (ec *executionContext) unmarshalInputNewContract(ctx context.Context, obj interface{}) (model.NewContract, error) {
+	var it model.NewContract
+	var asMap = obj.(map[string]interface{})
+
+	for k, v := range asMap {
+		switch k {
+		case "projectId":
+			var err error
+			it.ProjectID, err = ec.unmarshalNUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "index":
+			var err error
+			it.Index, err = ec.unmarshalNInt2int(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "title":
+			var err error
+			it.Title, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "script":
+			var err error
+			it.Script, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputNewProject(ctx context.Context, obj interface{}) (model.NewProject, error) {
 	var it model.NewProject
 	var asMap = obj.(map[string]interface{})
@@ -5046,6 +5734,12 @@ func (ec *executionContext) unmarshalInputNewProject(ctx context.Context, obj in
 			if err != nil {
 				return it, err
 			}
+		case "contracts":
+			var err error
+			it.Contracts, err = ec.unmarshalONewProjectContract2ᚕᚖgithubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐNewProjectContractᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "transactionTemplates":
 			var err error
 			it.TransactionTemplates, err = ec.unmarshalONewProjectTransactionTemplate2ᚕᚖgithubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐNewProjectTransactionTemplateᚄ(ctx, v)
@@ -5055,6 +5749,36 @@ func (ec *executionContext) unmarshalInputNewProject(ctx context.Context, obj in
 		case "scriptTemplates":
 			var err error
 			it.ScriptTemplates, err = ec.unmarshalONewProjectScriptTemplate2ᚕᚖgithubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐNewProjectScriptTemplateᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputNewProjectContract(ctx context.Context, obj interface{}) (model.NewProjectContract, error) {
+	var it model.NewProjectContract
+	var asMap = obj.(map[string]interface{})
+
+	for k, v := range asMap {
+		switch k {
+		case "index":
+			var err error
+			it.Index, err = ec.unmarshalNInt2int(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "title":
+			var err error
+			it.Title, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "script":
+			var err error
+			it.Script, err = ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -5256,6 +5980,12 @@ func (ec *executionContext) unmarshalInputUpdateAccount(ctx context.Context, obj
 			if err != nil {
 				return it, err
 			}
+		case "contractId":
+			var err error
+			it.ContractID, err = ec.unmarshalOUUID2ᚖgithubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "draftCode":
 			var err error
 			it.DraftCode, err = ec.unmarshalOString2ᚖstring(ctx, v)
@@ -5265,6 +5995,54 @@ func (ec *executionContext) unmarshalInputUpdateAccount(ctx context.Context, obj
 		case "deployedCode":
 			var err error
 			it.DeployedCode, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputUpdateContract(ctx context.Context, obj interface{}) (model.UpdateContract, error) {
+	var it model.UpdateContract
+	var asMap = obj.(map[string]interface{})
+
+	for k, v := range asMap {
+		switch k {
+		case "id":
+			var err error
+			it.ID, err = ec.unmarshalNUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "title":
+			var err error
+			it.Title, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "projectId":
+			var err error
+			it.ProjectID, err = ec.unmarshalNUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "index":
+			var err error
+			it.Index, err = ec.unmarshalOInt2ᚖint(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "script":
+			var err error
+			it.Script, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "deployedScript":
+			var err error
+			it.DeployedScript, err = ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -5448,6 +6226,52 @@ func (ec *executionContext) _Account(ctx context.Context, sel ast.SelectionSet, 
 	return out
 }
 
+var contractImplementors = []string{"Contract"}
+
+func (ec *executionContext) _Contract(ctx context.Context, sel ast.SelectionSet, obj *model.Contract) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.RequestContext, sel, contractImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Contract")
+		case "id":
+			out.Values[i] = ec._Contract_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "accountId":
+			out.Values[i] = ec._Contract_accountId(ctx, field, obj)
+		case "index":
+			out.Values[i] = ec._Contract_index(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "title":
+			out.Values[i] = ec._Contract_title(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "script":
+			out.Values[i] = ec._Contract_script(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "deployedScript":
+			out.Values[i] = ec._Contract_deployedScript(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var eventImplementors = []string{"Event"}
 
 func (ec *executionContext) _Event(ctx context.Context, sel ast.SelectionSet, obj *model.Event) graphql.Marshaler {
@@ -5507,6 +6331,21 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			}
 		case "updateAccount":
 			out.Values[i] = ec._Mutation_updateAccount(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "createContract":
+			out.Values[i] = ec._Mutation_createContract(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "updateContract":
+			out.Values[i] = ec._Mutation_updateContract(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "deleteContract":
+			out.Values[i] = ec._Mutation_deleteContract(ctx, field)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
@@ -5714,6 +6553,17 @@ func (ec *executionContext) _Project(ctx context.Context, sel ast.SelectionSet, 
 				res = ec._Project_accounts(ctx, field, obj)
 				return res
 			})
+		case "contracts":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Project_contracts(ctx, field, obj)
+				return res
+			})
 		case "transactionTemplates":
 			field := field
 			out.Concurrently(i, func() (res graphql.Marshaler) {
@@ -5821,6 +6671,20 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_account(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
+		case "contract":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_contract(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&invalids, 1)
 				}
@@ -6378,6 +7242,20 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 	return res
 }
 
+func (ec *executionContext) marshalNContract2githubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐContract(ctx context.Context, sel ast.SelectionSet, v model.Contract) graphql.Marshaler {
+	return ec._Contract(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNContract2ᚖgithubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐContract(ctx context.Context, sel ast.SelectionSet, v *model.Contract) graphql.Marshaler {
+	if v == nil {
+		if !ec.HasError(graphql.GetResolverContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._Contract(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalNEvent2ᚕgithubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐEvent(ctx context.Context, sel ast.SelectionSet, v []model.Event) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
@@ -6429,8 +7307,24 @@ func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.Selecti
 	return res
 }
 
+func (ec *executionContext) unmarshalNNewContract2githubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐNewContract(ctx context.Context, v interface{}) (model.NewContract, error) {
+	return ec.unmarshalInputNewContract(ctx, v)
+}
+
 func (ec *executionContext) unmarshalNNewProject2githubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐNewProject(ctx context.Context, v interface{}) (model.NewProject, error) {
 	return ec.unmarshalInputNewProject(ctx, v)
+}
+
+func (ec *executionContext) unmarshalNNewProjectContract2githubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐNewProjectContract(ctx context.Context, v interface{}) (model.NewProjectContract, error) {
+	return ec.unmarshalInputNewProjectContract(ctx, v)
+}
+
+func (ec *executionContext) unmarshalNNewProjectContract2ᚖgithubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐNewProjectContract(ctx context.Context, v interface{}) (*model.NewProjectContract, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalNNewProjectContract2githubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐNewProjectContract(ctx, v)
+	return &res, err
 }
 
 func (ec *executionContext) unmarshalNNewProjectScriptTemplate2githubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐNewProjectScriptTemplate(ctx context.Context, v interface{}) (model.NewProjectScriptTemplate, error) {
@@ -6620,6 +7514,10 @@ func (ec *executionContext) marshalNUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx
 
 func (ec *executionContext) unmarshalNUpdateAccount2githubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐUpdateAccount(ctx context.Context, v interface{}) (model.UpdateAccount, error) {
 	return ec.unmarshalInputUpdateAccount(ctx, v)
+}
+
+func (ec *executionContext) unmarshalNUpdateContract2githubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐUpdateContract(ctx context.Context, v interface{}) (model.UpdateContract, error) {
+	return ec.unmarshalInputUpdateContract(ctx, v)
 }
 
 func (ec *executionContext) unmarshalNUpdateProject2githubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐUpdateProject(ctx context.Context, v interface{}) (model.UpdateProject, error) {
@@ -6987,6 +7885,46 @@ func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast
 	return ec.marshalOBoolean2bool(ctx, sel, *v)
 }
 
+func (ec *executionContext) marshalOContract2ᚕᚖgithubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐContractᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Contract) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		rctx := &graphql.ResolverContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithResolverContext(ctx, rctx)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNContract2ᚖgithubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐContract(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+	return ret
+}
+
 func (ec *executionContext) marshalOEvent2githubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐEvent(ctx context.Context, sel ast.SelectionSet, v model.Event) graphql.Marshaler {
 	return ec._Event(ctx, sel, &v)
 }
@@ -7012,6 +7950,26 @@ func (ec *executionContext) marshalOInt2ᚖint(ctx context.Context, sel ast.Sele
 		return graphql.Null
 	}
 	return ec.marshalOInt2int(ctx, sel, *v)
+}
+
+func (ec *executionContext) unmarshalONewProjectContract2ᚕᚖgithubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐNewProjectContractᚄ(ctx context.Context, v interface{}) ([]*model.NewProjectContract, error) {
+	var vSlice []interface{}
+	if v != nil {
+		if tmp1, ok := v.([]interface{}); ok {
+			vSlice = tmp1
+		} else {
+			vSlice = []interface{}{v}
+		}
+	}
+	var err error
+	res := make([]*model.NewProjectContract, len(vSlice))
+	for i := range vSlice {
+		res[i], err = ec.unmarshalNNewProjectContract2ᚖgithubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐNewProjectContract(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
 }
 
 func (ec *executionContext) unmarshalONewProjectScriptTemplate2ᚕᚖgithubᚗcomᚋdapperlabsᚋflowᚑplaygroundᚑapiᚋmodelᚐNewProjectScriptTemplateᚄ(ctx context.Context, v interface{}) ([]*model.NewProjectScriptTemplate, error) {

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,10 @@ github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 h1:y5HC9v93H5EPKqaS1UYVg1uYah5Xf51mBfIoWehClUQ=
@@ -907,7 +909,9 @@ github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521/go.mod h1:RvLn4FgxWubr
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.19.0 h1:hYz4ZVdUgjXTBUmrkrw55j1nHx68LfOKIQk5IYtyScg=
 github.com/rs/zerolog v1.19.0/go.mod h1:IzD0RJ65iWH0w97OQQebJEvTZYvsCUm9WVLWBQrJRjo=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
@@ -936,6 +940,7 @@ github.com/shurcooL/notifications v0.0.0-20181007000457-627ab5aea122/go.mod h1:b
 github.com/shurcooL/octicon v0.0.0-20181028054416-fa4f57f9efb2/go.mod h1:eWdoE5JD4R5UVWDucdOPg1g2fqQRq78IQa9zlOV1vpQ=
 github.com/shurcooL/reactions v0.0.0-20181006231557-f2e0b4ca5b82/go.mod h1:TCR1lToEk4d2s07G3XGfz2QrgHXg4RJBvjrOozvoWfk=
 github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/shurcooL/users v0.0.0-20180125191416-49c67e49c537/go.mod h1:QJTqeLYEDaXHZDBsXlPCDqdhQuJkuw4NOtaxYe3xii4=
 github.com/shurcooL/vfsgen v0.0.0-20180121065927-ffb13db8def0/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
@@ -999,6 +1004,7 @@ github.com/uber/jaeger-lib v2.3.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+github.com/urfave/cli v1.22.1 h1:+mkCCcOFKPnCmVYVcURKps1Xe+3zP90gSYGNfRkjoIY=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vektah/dataloaden v0.2.1-0.20190515034641-a19b9a6e7c9e/go.mod h1:/HUdMve7rvxZma+2ZELQeNh88+003LL7Pf/CZ089j8U=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -28,6 +28,8 @@ models:
     model: github.com/dapperlabs/flow-playground-api/model.Account
   UpdateAccount:
     model: github.com/dapperlabs/flow-playground-api/model.UpdateAccount
+  Contract:
+    model: github.com/dapperlabs/flow-playground-api/model.Contract
   TransactionTemplate:
     model: github.com/dapperlabs/flow-playground-api/model.TransactionTemplate
   TransactionExecution:

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -121,7 +121,7 @@ func migrateTest(startVersion *semver.Version, f func(t *testing.T, c migrateTes
 		scripts := controller.NewScripts(store, computer)
 		projects := controller.NewProjects(startVersion, store, computer, numAccounts)
 
-		migrator := migrate.NewMigrator(projects)
+		migrator := migrate.NewMigrator(projects, store)
 
 		user := model.User{
 			ID: uuid.New(),

--- a/model/account.go
+++ b/model/account.go
@@ -69,10 +69,11 @@ func (a *InternalAccount) marshalState() (string, error) {
 }
 
 type UpdateAccount struct {
-	ID                uuid.UUID `json:"id"`
-	ProjectID         uuid.UUID `json:"projectId"`
-	DraftCode         *string   `json:"draftCode"`
-	DeployedCode      *string   `json:"deployedCode"`
+	ID                uuid.UUID  `json:"id"`
+	ProjectID         uuid.UUID  `json:"projectId"`
+	ContractID        *uuid.UUID `json:"contractId"`
+	DraftCode         *string    `json:"draftCode"`
+	DeployedCode      *string    `json:"deployedCode"`
 	DeployedContracts *[]string
 }
 

--- a/model/account.go
+++ b/model/account.go
@@ -33,6 +33,11 @@ type InternalAccount struct {
 	DeployedContracts []string
 	marshalledState   string
 	unmarshalledState AccountState
+
+	// for migrating code inside
+	// Account struct to seperate Contract struct
+	DraftCode    string
+	DeployedCode string
 }
 
 func (a *InternalAccount) State() (AccountState, error) {
@@ -85,6 +90,10 @@ func (a *InternalAccount) Load(ps []datastore.Property) error {
 		Address           []byte
 		DeployedContracts []string
 		State             string
+
+		// for migration to new Contract struct
+		DraftCode    string
+		DeployedCode string
 	}{}
 
 	if err := datastore.LoadStruct(&tmp, ps); err != nil {
@@ -105,6 +114,9 @@ func (a *InternalAccount) Load(ps []datastore.Property) error {
 
 	a.marshalledState = tmp.State
 	a.unmarshalledState = nil
+
+	a.DraftCode = tmp.DraftCode
+	a.DeployedCode = tmp.DeployedCode
 
 	return nil
 }

--- a/model/account.go
+++ b/model/account.go
@@ -30,8 +30,6 @@ type InternalAccount struct {
 	ProjectChildID
 	Index             int
 	Address           Address
-	DraftCode         string
-	DeployedCode      string
 	DeployedContracts []string
 	marshalledState   string
 	unmarshalledState AccountState
@@ -72,8 +70,6 @@ type UpdateAccount struct {
 	ID                uuid.UUID  `json:"id"`
 	ProjectID         uuid.UUID  `json:"projectId"`
 	ContractID        *uuid.UUID `json:"contractId"`
-	DraftCode         *string    `json:"draftCode"`
-	DeployedCode      *string    `json:"deployedCode"`
 	DeployedContracts *[]string
 }
 
@@ -87,8 +83,6 @@ func (a *InternalAccount) Load(ps []datastore.Property) error {
 		ProjectID         string
 		Index             int
 		Address           []byte
-		DraftCode         string
-		DeployedCode      string
 		DeployedContracts []string
 		State             string
 	}{}
@@ -107,8 +101,6 @@ func (a *InternalAccount) Load(ps []datastore.Property) error {
 
 	a.Index = tmp.Index
 	copy(a.Address[:], tmp.Address[:])
-	a.DraftCode = tmp.DraftCode
-	a.DeployedCode = tmp.DeployedCode
 	a.DeployedContracts = tmp.DeployedContracts
 
 	a.marshalledState = tmp.State
@@ -146,16 +138,6 @@ func (a *InternalAccount) Save() ([]datastore.Property, error) {
 			Value: a.Address[:],
 		},
 		{
-			Name:    "DraftCode",
-			Value:   a.DraftCode,
-			NoIndex: true,
-		},
-		{
-			Name:    "DeployedCode",
-			Value:   a.DeployedCode,
-			NoIndex: true,
-		},
-		{
 			Name:  "DeployedContracts",
 			Value: deployedContracts,
 		},
@@ -173,8 +155,6 @@ func (a *InternalAccount) Export() *Account {
 		ProjectID:         a.ProjectID,
 		Index:             a.Index,
 		Address:           a.Address,
-		DraftCode:         a.DraftCode,
-		DeployedCode:      a.DeployedCode,
 		DeployedContracts: a.DeployedContracts,
 		// NOTE: State left intentionally blank
 	}
@@ -199,8 +179,6 @@ type Account struct {
 	ProjectID         uuid.UUID
 	Index             int
 	Address           Address
-	DraftCode         string
-	DeployedCode      string
 	DeployedContracts []string
 	State             string
 }

--- a/model/contract.go
+++ b/model/contract.go
@@ -1,0 +1,105 @@
+/*
+* Flow Playground
+*
+* Copyright 2019-2021 Dapper Labs, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package model
+
+import (
+	"cloud.google.com/go/datastore"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+)
+
+type Contract struct {
+	ProjectChildID
+	AccountID      uuid.UUID
+	Title          string
+	Index          int
+	Script         string
+	DeployedScript string
+}
+
+func (c *Contract) NameKey() *datastore.Key {
+	return datastore.NameKey("Contract", c.ID.String(), ProjectNameKey(c.ProjectID))
+}
+
+func (c *Contract) Load(ps []datastore.Property) error {
+	tmp := struct {
+		ID             string
+		ProjectID      string
+		AccountID      string
+		Title          string
+		Index          int
+		Script         string
+		DeployedScript string
+	}{}
+
+	if err := datastore.LoadStruct(&tmp, ps); err != nil {
+		return err
+	}
+
+	if err := c.ID.UnmarshalText([]byte(tmp.ID)); err != nil {
+		return errors.Wrap(err, "failed to decode contract UUID")
+	}
+	if err := c.ProjectID.UnmarshalText([]byte(tmp.ProjectID)); err != nil {
+		return errors.Wrap(err, "failed to decode project UUID")
+	}
+	if err := c.AccountID.UnmarshalText([]byte(tmp.AccountID)); err != nil {
+		return errors.Wrap(err, "failed to decode account UUID")
+	}
+
+	c.Title = tmp.Title
+	c.Index = tmp.Index
+	c.Script = tmp.Script
+	c.DeployedScript = tmp.DeployedScript
+	return nil
+}
+
+func (c *Contract) Save() ([]datastore.Property, error) {
+	return []datastore.Property{
+		{
+			Name:  "ID",
+			Value: c.ID.String(),
+		},
+		{
+			Name:  "ProjectID",
+			Value: c.ProjectID.String(),
+		},
+		{
+			Name:  "AccountID",
+			Value: c.AccountID.String(),
+		},
+		{
+			Name:  "Title",
+			Value: c.Title,
+		},
+		{
+			Name:  "Index",
+			Value: c.Index,
+		},
+		{
+			Name:    "Script",
+			Value:   c.Script,
+			NoIndex: true,
+		},
+		{
+			Name:    "DeployedScript",
+			Value:   c.DeployedScript,
+			NoIndex: true,
+		},
+	}, nil
+}

--- a/model/contract.go
+++ b/model/contract.go
@@ -20,13 +20,11 @@ package model
 
 import (
 	"cloud.google.com/go/datastore"
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
 
 type Contract struct {
 	ProjectChildID
-	AccountID      uuid.UUID
 	Title          string
 	Index          int
 	Script         string
@@ -41,7 +39,6 @@ func (c *Contract) Load(ps []datastore.Property) error {
 	tmp := struct {
 		ID             string
 		ProjectID      string
-		AccountID      string
 		Title          string
 		Index          int
 		Script         string
@@ -57,9 +54,6 @@ func (c *Contract) Load(ps []datastore.Property) error {
 	}
 	if err := c.ProjectID.UnmarshalText([]byte(tmp.ProjectID)); err != nil {
 		return errors.Wrap(err, "failed to decode project UUID")
-	}
-	if err := c.AccountID.UnmarshalText([]byte(tmp.AccountID)); err != nil {
-		return errors.Wrap(err, "failed to decode account UUID")
 	}
 
 	c.Title = tmp.Title
@@ -78,10 +72,6 @@ func (c *Contract) Save() ([]datastore.Property, error) {
 		{
 			Name:  "ProjectID",
 			Value: c.ProjectID.String(),
-		},
-		{
-			Name:  "AccountID",
-			Value: c.AccountID.String(),
 		},
 		{
 			Name:  "Title",

--- a/model/contract.go
+++ b/model/contract.go
@@ -25,10 +25,10 @@ import (
 
 type Contract struct {
 	ProjectChildID
-	Title          string
-	Index          int
-	Script         string
-	DeployedScript string
+	Title        string
+	AccountIndex int
+	Code         string
+	DeployedCode string
 }
 
 func (c *Contract) NameKey() *datastore.Key {
@@ -37,12 +37,12 @@ func (c *Contract) NameKey() *datastore.Key {
 
 func (c *Contract) Load(ps []datastore.Property) error {
 	tmp := struct {
-		ID             string
-		ProjectID      string
-		Title          string
-		Index          int
-		Script         string
-		DeployedScript string
+		ID           string
+		ProjectID    string
+		Title        string
+		AccountIndex int
+		Code         string
+		DeployedCode string
 	}{}
 
 	if err := datastore.LoadStruct(&tmp, ps); err != nil {
@@ -57,9 +57,9 @@ func (c *Contract) Load(ps []datastore.Property) error {
 	}
 
 	c.Title = tmp.Title
-	c.Index = tmp.Index
-	c.Script = tmp.Script
-	c.DeployedScript = tmp.DeployedScript
+	c.AccountIndex = tmp.AccountIndex
+	c.Code = tmp.Code
+	c.DeployedCode = tmp.DeployedCode
 	return nil
 }
 
@@ -78,17 +78,17 @@ func (c *Contract) Save() ([]datastore.Property, error) {
 			Value: c.Title,
 		},
 		{
-			Name:  "Index",
-			Value: c.Index,
+			Name:  "AccountIndex",
+			Value: c.AccountIndex,
 		},
 		{
-			Name:    "Script",
-			Value:   c.Script,
+			Name:    "Code",
+			Value:   c.Code,
 			NoIndex: true,
 		},
 		{
-			Name:    "DeployedScript",
-			Value:   c.DeployedScript,
+			Name:    "DeployedCode",
+			Value:   c.DeployedCode,
 			NoIndex: true,
 		},
 	}, nil

--- a/model/models_gen.go
+++ b/model/models_gen.go
@@ -7,22 +7,14 @@ import (
 	"github.com/google/uuid"
 )
 
-/*type Contract struct {
-	ID             uuid.UUID `json:"id"`
-	Index          int       `json:"index"`
-	Title          string    `json:"title"`
-	Script         string    `json:"script"`
-	DeployedScript *string   `json:"deployedScript"`
-}*/
-
 type DeployContract struct {
-	ID             uuid.UUID `json:"id"`
-	Title          *string   `json:"title"`
-	ProjectID      uuid.UUID `json:"projectId"`
-	AccountID      uuid.UUID `json:"accountId"`
-	Index          *int      `json:"index"`
-	Script         *string   `json:"script"`
-	DeployedScript *string   `json:"deployedScript"`
+	ID           uuid.UUID `json:"id"`
+	Title        *string   `json:"title"`
+	ProjectID    uuid.UUID `json:"projectId"`
+	AccountID    uuid.UUID `json:"accountId"`
+	AccountIndex *int      `json:"accountIndex"`
+	Code         *string   `json:"code"`
+	DeployedCode *string   `json:"deployedCode"`
 }
 
 type Event struct {
@@ -31,10 +23,10 @@ type Event struct {
 }
 
 type NewContract struct {
-	ProjectID uuid.UUID `json:"projectId"`
-	Index     int       `json:"index"`
-	Title     string    `json:"title"`
-	Script    string    `json:"script"`
+	ProjectID    uuid.UUID `json:"projectId"`
+	AccountIndex int       `json:"accountIndex"`
+	Title        string    `json:"title"`
+	Code         string    `json:"code"`
 }
 
 type NewProject struct {
@@ -48,9 +40,9 @@ type NewProject struct {
 }
 
 type NewProjectContract struct {
-	Index  int    `json:"index"`
-	Title  string `json:"title"`
-	Script string `json:"script"`
+	AccountIndex int    `json:"accountIndex"`
+	Title        string `json:"title"`
+	Code         string `json:"code"`
 }
 
 type NewProjectScriptTemplate struct {
@@ -106,12 +98,12 @@ type ProgramPosition struct {
 }
 
 type UpdateContract struct {
-	ID             uuid.UUID `json:"id"`
-	Title          *string   `json:"title"`
-	ProjectID      uuid.UUID `json:"projectId"`
-	Index          *int      `json:"index"`
-	Script         *string   `json:"script"`
-	DeployedScript *string   `json:"deployedScript"`
+	ID           uuid.UUID `json:"id"`
+	Title        *string   `json:"title"`
+	ProjectID    uuid.UUID `json:"projectId"`
+	AccountIndex *int      `json:"accountIndex"`
+	Code         *string   `json:"code"`
+	DeployedCode *string   `json:"deployedCode"`
 }
 
 type UpdateProject struct {

--- a/model/models_gen.go
+++ b/model/models_gen.go
@@ -7,9 +7,25 @@ import (
 	"github.com/google/uuid"
 )
 
+/*type Contract struct {
+	ID             uuid.UUID  `json:"id"`
+	AccountID      *uuid.UUID `json:"accountId"`
+	Index          int        `json:"index"`
+	Title          string     `json:"title"`
+	Script         string     `json:"script"`
+	DeployedScript *string    `json:"deployedScript"`
+}*/
+
 type Event struct {
 	Type   string   `json:"type"`
 	Values []string `json:"values"`
+}
+
+type NewContract struct {
+	ProjectID uuid.UUID `json:"projectId"`
+	Index     int       `json:"index"`
+	Title     string    `json:"title"`
+	Script    string    `json:"script"`
 }
 
 type NewProject struct {
@@ -17,8 +33,15 @@ type NewProject struct {
 	Title                string                           `json:"title"`
 	Seed                 int                              `json:"seed"`
 	Accounts             []string                         `json:"accounts"`
+	Contracts            []*NewProjectContract            `json:"contracts"`
 	TransactionTemplates []*NewProjectTransactionTemplate `json:"transactionTemplates"`
 	ScriptTemplates      []*NewProjectScriptTemplate      `json:"scriptTemplates"`
+}
+
+type NewProjectContract struct {
+	Index  int    `json:"index"`
+	Title  string `json:"title"`
+	Script string `json:"script"`
 }
 
 type NewProjectScriptTemplate struct {
@@ -71,6 +94,15 @@ type ProgramPosition struct {
 	Offset int `json:"offset"`
 	Line   int `json:"line"`
 	Column int `json:"column"`
+}
+
+type UpdateContract struct {
+	ID             uuid.UUID `json:"id"`
+	Title          *string   `json:"title"`
+	ProjectID      uuid.UUID `json:"projectId"`
+	Index          *int      `json:"index"`
+	Script         *string   `json:"script"`
+	DeployedScript *string   `json:"deployedScript"`
 }
 
 type UpdateProject struct {

--- a/model/models_gen.go
+++ b/model/models_gen.go
@@ -15,6 +15,16 @@ import (
 	DeployedScript *string   `json:"deployedScript"`
 }*/
 
+type DeployContract struct {
+	ID             uuid.UUID `json:"id"`
+	Title          *string   `json:"title"`
+	ProjectID      uuid.UUID `json:"projectId"`
+	AccountID      uuid.UUID `json:"accountId"`
+	Index          *int      `json:"index"`
+	Script         *string   `json:"script"`
+	DeployedScript *string   `json:"deployedScript"`
+}
+
 type Event struct {
 	Type   string   `json:"type"`
 	Values []string `json:"values"`

--- a/model/models_gen.go
+++ b/model/models_gen.go
@@ -8,12 +8,11 @@ import (
 )
 
 /*type Contract struct {
-	ID             uuid.UUID  `json:"id"`
-	AccountID      *uuid.UUID `json:"accountId"`
-	Index          int        `json:"index"`
-	Title          string     `json:"title"`
-	Script         string     `json:"script"`
-	DeployedScript *string    `json:"deployedScript"`
+	ID             uuid.UUID `json:"id"`
+	Index          int       `json:"index"`
+	Title          string    `json:"title"`
+	Script         string    `json:"script"`
+	DeployedScript *string   `json:"deployedScript"`
 }*/
 
 type Event struct {
@@ -97,13 +96,12 @@ type ProgramPosition struct {
 }
 
 type UpdateContract struct {
-	ID             uuid.UUID  `json:"id"`
-	Title          *string    `json:"title"`
-	ProjectID      uuid.UUID  `json:"projectId"`
-	AccountID      *uuid.UUID `json:"accountId"`
-	Index          *int       `json:"index"`
-	Script         *string    `json:"script"`
-	DeployedScript *string    `json:"deployedScript"`
+	ID             uuid.UUID `json:"id"`
+	Title          *string   `json:"title"`
+	ProjectID      uuid.UUID `json:"projectId"`
+	Index          *int      `json:"index"`
+	Script         *string   `json:"script"`
+	DeployedScript *string   `json:"deployedScript"`
 }
 
 type UpdateProject struct {

--- a/model/models_gen.go
+++ b/model/models_gen.go
@@ -97,12 +97,13 @@ type ProgramPosition struct {
 }
 
 type UpdateContract struct {
-	ID             uuid.UUID `json:"id"`
-	Title          *string   `json:"title"`
-	ProjectID      uuid.UUID `json:"projectId"`
-	Index          *int      `json:"index"`
-	Script         *string   `json:"script"`
-	DeployedScript *string   `json:"deployedScript"`
+	ID             uuid.UUID  `json:"id"`
+	Title          *string    `json:"title"`
+	ProjectID      uuid.UUID  `json:"projectId"`
+	AccountID      *uuid.UUID `json:"accountId"`
+	Index          *int       `json:"index"`
+	Script         *string    `json:"script"`
+	DeployedScript *string    `json:"deployedScript"`
 }
 
 type UpdateProject struct {

--- a/playground_test.go
+++ b/playground_test.go
@@ -2231,7 +2231,7 @@ func TestAccounts(t *testing.T) {
 
 		assert.Equal(t, respB.Contract.ID, respC.UpdateContract.ID)
 		assert.Equal(t, respB.Contract.Index, respC.UpdateContract.Index)
-		assert.Equal(t, "organce", respC.UpdateContract.Script)
+		assert.Equal(t, "orange", respC.UpdateContract.Script)
 	})
 
 	t.Run("Update non-existent account", func(t *testing.T) {

--- a/resolver.go
+++ b/resolver.go
@@ -63,7 +63,7 @@ func NewResolver(
 ) *Resolver {
 	projects := controller.NewProjects(version, store, computer, MaxAccounts)
 	scripts := controller.NewScripts(store, computer)
-	migrator := migrate.NewMigrator(projects)
+	migrator := migrate.NewMigrator(projects, store)
 
 	return &Resolver{
 		version:  version,
@@ -861,7 +861,7 @@ func (r *queryResolver) Project(ctx context.Context, id uuid.UUID) (*model.Proje
 
 	// only migrate if current user has access to this project
 
-	migrated, err := r.migrator.MigrateProject(id, proj.Version, r.version)
+	migrated, err := r.migrator.MigrateProject(id, proj.Version, semver.MustParse("v0.8.0"))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to migrate project")
 	}

--- a/resolver.go
+++ b/resolver.go
@@ -362,11 +362,11 @@ func (r *mutationResolver) DeployContract(ctx context.Context, input model.Deplo
 		toTransactionBody(tx),
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to deploy account code")
+		return nil, errors.Wrap(err, "failed to deploy contract code")
 	}
 
 	if result.Err != nil {
-		return nil, errors.Wrap(result.Err, "failed to deploy account code")
+		return nil, errors.Wrap(result.Err, "failed to deploy contract code")
 	}
 
 	var inputCon = model.UpdateContract{

--- a/resolver.go
+++ b/resolver.go
@@ -230,7 +230,7 @@ func (r *mutationResolver) UpdateAccount(ctx context.Context, input model.Update
 	var inputCon = model.UpdateContract{
 		ID:             con.ID,
 		ProjectID:      con.ProjectID,
-		DeployedScript: input.DeployedCode,
+		DeployedScript: &source,
 		Title:          &contractName,
 	}
 

--- a/resolver.go
+++ b/resolver.go
@@ -423,8 +423,6 @@ func (r *mutationResolver) DeployContract(ctx context.Context, input model.Deplo
 func (r *mutationResolver) DeleteContract(ctx context.Context, id uuid.UUID, projectID uuid.UUID) (uuid.UUID, error) {
 	var proj model.InternalProject
 
-	//soe to-do delete contract from Flow as well?
-
 	err := r.projects.Get(projectID, &proj)
 	if err != nil {
 		return uuid.Nil, errors.Wrap(err, "failed to get project")

--- a/resolver.go
+++ b/resolver.go
@@ -255,9 +255,9 @@ func (r *mutationResolver) CreateContract(ctx context.Context, input model.NewCo
 			ID:        uuid.New(),
 			ProjectID: input.ProjectID,
 		},
-		Index:  input.Index,
-		Title:  input.Title,
-		Script: input.Script,
+		AccountIndex: input.AccountIndex,
+		Title:        input.Title,
+		Code:         input.Code,
 	}
 
 	var proj model.InternalProject
@@ -321,7 +321,7 @@ func (r *mutationResolver) DeployContract(ctx context.Context, input model.Deplo
 	}
 
 	// Redeploy: clear all state if this contract has been deployed before
-	if con.DeployedScript != "" {
+	if con.DeployedCode != "" {
 		err := r.projects.Reset(&proj)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to clear project state")
@@ -336,7 +336,7 @@ func (r *mutationResolver) DeployContract(ctx context.Context, input model.Deplo
 	}
 
 	address := acc.Address.ToFlowAddress()
-	source := *input.DeployedScript
+	source := *input.DeployedCode
 	contractName, err := getSourceContractName(source)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to deploy account code")
@@ -370,11 +370,11 @@ func (r *mutationResolver) DeployContract(ctx context.Context, input model.Deplo
 	}
 
 	var inputCon = model.UpdateContract{
-		ID:             input.ID,
-		ProjectID:      input.ProjectID,
-		Script:         input.DeployedScript,
-		DeployedScript: input.DeployedScript,
-		Title:          &contractName,
+		ID:           input.ID,
+		ProjectID:    input.ProjectID,
+		Code:         input.DeployedCode,
+		DeployedCode: input.DeployedCode,
+		Title:        &contractName,
 	}
 
 	err = r.store.UpdateContract(inputCon, &con)

--- a/resolver.go
+++ b/resolver.go
@@ -136,8 +136,6 @@ func (r *mutationResolver) UpdateProject(ctx context.Context, input model.Update
 	return proj.ExportPublicMutable(), nil
 }
 
-//soe modify this first to deploy contract script (instead of account's code and deployedCode)
-//soe this needs to be updated/removed along with removing legacy account draft and deployed code
 func (r *mutationResolver) UpdateAccount(ctx context.Context, input model.UpdateAccount) (*model.Account, error) {
 
 	var proj model.InternalProject

--- a/schema.graphql
+++ b/schema.graphql
@@ -35,7 +35,6 @@ type Account {
 
 type Contract {
   id: UUID!
-  accountId: UUID
   index: Int!
   title: String!
   script: String!
@@ -153,7 +152,6 @@ input UpdateContract {
   id: UUID!
   title: String
   projectId: UUID!
-  accountId: UUID
   index: Int
   script: String
   deployedScript: String

--- a/schema.graphql
+++ b/schema.graphql
@@ -33,10 +33,10 @@ type Account {
 
 type Contract {
   id: UUID!
-  index: Int!
+  accountIndex: Int!
   title: String!
-  script: String!
-  deployedScript: String
+  code: String!
+  deployedCode: String
 }
 
 type ProgramError {
@@ -110,9 +110,9 @@ input NewProject {
 }
 
 input NewProjectContract {
-  index: Int!
+  accountIndex: Int!
   title: String!
-  script: String!
+  code: String!
 }
 
 input NewProjectTransactionTemplate {
@@ -139,18 +139,18 @@ input UpdateAccount {
 
 input NewContract {
   projectId: UUID!
-  index: Int!
+  accountIndex: Int!
   title: String!
-  script: String!
+  code: String!
 }
 
 input UpdateContract {
   id: UUID!
   title: String
   projectId: UUID!
-  index: Int
-  script: String
-  deployedScript: String
+  accountIndex: Int
+  code: String
+  deployedCode: String
 }
 
 input DeployContract {
@@ -158,9 +158,9 @@ input DeployContract {
   title: String
   projectId: UUID!
   accountId: UUID!
-  index: Int
-  script: String
-  deployedScript: String
+  accountIndex: Int
+  code: String
+  deployedCode: String
 }
 
 input NewTransactionTemplate {

--- a/schema.graphql
+++ b/schema.graphql
@@ -17,6 +17,7 @@ type Project {
   persist: Boolean
   mutable: Boolean
   accounts: [Account!]
+  contracts: [Contract!]
   transactionTemplates: [TransactionTemplate!]
   transactionExecutions: [TransactionExecution!]
   scriptTemplates: [ScriptTemplate!]
@@ -30,6 +31,15 @@ type Account {
   deployedCode: String!
   deployedContracts: [String!]!
   state: String!
+}
+
+type Contract {
+  id: UUID!
+  accountId: UUID
+  accountIndex: Int!
+  title: String!
+  script: String!
+  deployedScript: String
 }
 
 type ProgramError {
@@ -87,6 +97,7 @@ type Query {
   project(id: UUID!): Project!
 
   account(id: UUID!, projectId: UUID!): Account!
+  contract(id: UUID!, projectId: UUID!): Contract!
   transactionTemplate(id: UUID!, projectId: UUID!): TransactionTemplate!
   scriptTemplate(id: UUID!, projectId: UUID!): ScriptTemplate!
 }
@@ -96,8 +107,15 @@ input NewProject {
   title: String!
   seed: Int!
   accounts: [String!]
+  contracts: [NewProjectContract!]
   transactionTemplates: [NewProjectTransactionTemplate!]
   scriptTemplates: [NewProjectScriptTemplate!]
+}
+
+input NewProjectContract {
+  AccountIndex: Int!
+  title: String!
+  script: String!
 }
 
 input NewProjectTransactionTemplate {
@@ -121,6 +139,22 @@ input UpdateAccount {
   projectId: UUID!
   draftCode: String
   deployedCode: String
+}
+
+input NewContract {
+  projectId: UUID!
+  accountIndex: Int!
+  title: String!
+  script: String!
+}
+
+input UpdateContract {
+  id: UUID!
+  title: String
+  projectId: UUID!
+  accountIndex: Int
+  script: String
+  deployedScript: String
 }
 
 input NewTransactionTemplate {
@@ -169,6 +203,10 @@ type Mutation {
   updateProject(input: UpdateProject!): Project!
 
   updateAccount(input: UpdateAccount!): Account!
+
+  createContract(input: NewContract!): Contract!
+  updateContract(input: UpdateContract!): Contract!
+  deleteContract(id: UUID!, projectId: UUID!): UUID!
 
   createTransactionTemplate(input: NewTransactionTemplate!): TransactionTemplate!
   updateTransactionTemplate(input: UpdateTransactionTemplate!): TransactionTemplate!

--- a/schema.graphql
+++ b/schema.graphql
@@ -27,8 +27,6 @@ type Project {
 type Account {
   id: UUID!
   address: Address!
-  draftCode: String!
-  deployedCode: String!
   deployedContracts: [String!]!
   state: String!
 }
@@ -137,8 +135,6 @@ input UpdateAccount {
   id: UUID!
   projectId: UUID!
   contractId: UUID
-  draftCode: String
-  deployedCode: String
 }
 
 input NewContract {
@@ -152,6 +148,16 @@ input UpdateContract {
   id: UUID!
   title: String
   projectId: UUID!
+  index: Int
+  script: String
+  deployedScript: String
+}
+
+input DeployContract {
+  id: UUID!
+  title: String
+  projectId: UUID!
+  accountId: UUID!
   index: Int
   script: String
   deployedScript: String
@@ -206,6 +212,7 @@ type Mutation {
 
   createContract(input: NewContract!): Contract!
   updateContract(input: UpdateContract!): Contract!
+  deployContract(input: DeployContract!): Contract!
   deleteContract(id: UUID!, projectId: UUID!): UUID!
 
   createTransactionTemplate(input: NewTransactionTemplate!): TransactionTemplate!

--- a/schema.graphql
+++ b/schema.graphql
@@ -36,7 +36,7 @@ type Account {
 type Contract {
   id: UUID!
   accountId: UUID
-  accountIndex: Int!
+  index: Int!
   title: String!
   script: String!
   deployedScript: String
@@ -113,7 +113,7 @@ input NewProject {
 }
 
 input NewProjectContract {
-  AccountIndex: Int!
+  index: Int!
   title: String!
   script: String!
 }
@@ -137,13 +137,14 @@ input UpdateProject {
 input UpdateAccount {
   id: UUID!
   projectId: UUID!
+  contractId: UUID
   draftCode: String
   deployedCode: String
 }
 
 input NewContract {
   projectId: UUID!
-  accountIndex: Int!
+  index: Int!
   title: String!
   script: String!
 }
@@ -152,7 +153,8 @@ input UpdateContract {
   id: UUID!
   title: String
   projectId: UUID!
-  accountIndex: Int
+  accountId: UUID
+  index: Int
   script: String
   deployedScript: String
 }
@@ -218,4 +220,3 @@ type Mutation {
   deleteScriptTemplate(id: UUID!, projectId: UUID!): UUID!
   createScriptExecution(input: NewScriptExecution!): ScriptExecution!
 }
-

--- a/storage/datastore/store.go
+++ b/storage/datastore/store.go
@@ -280,6 +280,13 @@ func (d *Datastore) ResetProjectState(newDeltas []delta.Delta, proj *model.Inter
 		return err
 	}
 
+	var cons []*model.Contract
+
+	err = d.GetContractsForProject(proj.ID, &cons)
+	if err != nil {
+		return err
+	}
+
 	var existingDeltas []*model.RegisterDelta
 
 	err = d.GetRegisterDeltasForProject(proj.ID, &existingDeltas)
@@ -313,7 +320,15 @@ func (d *Datastore) ResetProjectState(newDeltas []delta.Delta, proj *model.Inter
 			}
 		}
 
-		//soe to-do reset/clear deployed scripts from contracts
+		// reset/clear deployed scripts from contracts
+		for _, con := range cons {
+			con.DeployedScript = ""
+
+			_, err = tx.Put(con.NameKey(), con)
+			if err != nil {
+				return err
+			}
+		}
 
 		// erase all existing register deltas
 

--- a/storage/datastore/store.go
+++ b/storage/datastore/store.go
@@ -617,6 +617,10 @@ func (d *Datastore) UpdateContract(input model.UpdateContract, con *model.Contra
 			con.Script = *input.Script
 		}
 
+		if input.DeployedScript != nil {
+			con.DeployedScript = *input.DeployedScript
+		}
+
 		if input.Title != nil {
 			con.Title = *input.Title
 		}

--- a/storage/datastore/store.go
+++ b/storage/datastore/store.go
@@ -322,7 +322,7 @@ func (d *Datastore) ResetProjectState(newDeltas []delta.Delta, proj *model.Inter
 
 		// reset/clear deployed scripts from contracts
 		for _, con := range cons {
-			con.DeployedScript = ""
+			con.DeployedCode = ""
 
 			_, err = tx.Put(con.NameKey(), con)
 			if err != nil {
@@ -601,16 +601,16 @@ func (d *Datastore) UpdateContract(input model.UpdateContract, con *model.Contra
 			return err
 		}
 
-		if input.Index != nil {
-			con.Index = *input.Index
+		if input.AccountIndex != nil {
+			con.AccountIndex = *input.AccountIndex
 		}
 
-		if input.Script != nil {
-			con.Script = *input.Script
+		if input.Code != nil {
+			con.Code = *input.Code
 		}
 
-		if input.DeployedScript != nil {
-			con.DeployedScript = *input.DeployedScript
+		if input.DeployedCode != nil {
+			con.DeployedCode = *input.DeployedCode
 		}
 
 		if input.Title != nil {
@@ -635,7 +635,7 @@ func (d *Datastore) GetContract(id model.ProjectChildID, con *model.Contract) er
 }
 
 func (d *Datastore) GetContractsForProject(projectID uuid.UUID, cons *[]*model.Contract) error {
-	q := datastore.NewQuery("Contract").Ancestor(model.ProjectNameKey(projectID)).Order("Index")
+	q := datastore.NewQuery("Contract").Ancestor(model.ProjectNameKey(projectID)).Order("AccountIndex")
 	return d.getAll(q, cons)
 }
 

--- a/storage/datastore/store.go
+++ b/storage/datastore/store.go
@@ -167,9 +167,6 @@ func (d *Datastore) CreateProject(
 		}
 
 		for _, con := range cons {
-			//soe Index means AccountIndex
-			//con.Index = proj.ContractCount
-			//proj.ContractCount++
 			entitiesToPut = append(entitiesToPut, con)
 			keys = append(keys, con.NameKey())
 		}
@@ -579,10 +576,6 @@ func (d *Datastore) InsertContract(con *model.Contract) error {
 		if err != nil {
 			return err
 		}
-
-		//con.Index = proj.TransactionTemplateCount
-
-		//proj.ContractCount++
 
 		proj.UpdatedAt = time.Now()
 

--- a/storage/datastore/store.go
+++ b/storage/datastore/store.go
@@ -167,6 +167,7 @@ func (d *Datastore) CreateProject(
 		}
 
 		for _, con := range cons {
+			//soe Index means AccountIndex
 			//con.Index = proj.ContractCount
 			//proj.ContractCount++
 			entitiesToPut = append(entitiesToPut, con)

--- a/storage/datastore/store.go
+++ b/storage/datastore/store.go
@@ -303,10 +303,7 @@ func (d *Datastore) ResetProjectState(newDeltas []delta.Delta, proj *model.Inter
 
 	_, txErr := d.dsClient.RunInTransaction(ctx, func(tx *datastore.Transaction) error {
 
-		// clear deployed code from accounts
-
 		for _, acc := range accs {
-			acc.DeployedCode = ""
 			acc.DeployedContracts = nil
 			acc.SetState(make(model.AccountState))
 
@@ -315,6 +312,8 @@ func (d *Datastore) ResetProjectState(newDeltas []delta.Delta, proj *model.Inter
 				return err
 			}
 		}
+
+		//soe to-do reset/clear deployed scripts from contracts
 
 		// erase all existing register deltas
 
@@ -411,14 +410,6 @@ func (d *Datastore) UpdateAccount(input model.UpdateAccount, acc *model.Internal
 			return err
 		}
 
-		if input.DraftCode != nil {
-			acc.DraftCode = *input.DraftCode
-		}
-
-		if input.DeployedCode != nil {
-			acc.DeployedCode = *input.DeployedCode
-		}
-
 		if input.DeployedContracts != nil {
 			acc.DeployedContracts = *input.DeployedContracts
 		}
@@ -452,14 +443,6 @@ func (d *Datastore) UpdateAccountAfterDeployment(
 		err := tx.Get(acc.NameKey(), acc)
 		if err != nil {
 			return err
-		}
-
-		if input.DraftCode != nil {
-			acc.DraftCode = *input.DraftCode
-		}
-
-		if input.DeployedCode != nil {
-			acc.DeployedCode = *input.DeployedCode
 		}
 
 		if input.DeployedContracts != nil {

--- a/storage/memory/store.go
+++ b/storage/memory/store.go
@@ -416,16 +416,16 @@ func (s *Store) UpdateContract(input model.UpdateContract, con *model.Contract) 
 		c.Title = *input.Title
 	}
 
-	if input.Index != nil {
-		c.Index = *input.Index
+	if input.AccountIndex != nil {
+		c.AccountIndex = *input.AccountIndex
 	}
 
-	if input.Script != nil {
-		c.Script = *input.Script
+	if input.Code != nil {
+		c.Code = *input.Code
 	}
 
-	if input.DeployedScript != nil {
-		c.DeployedScript = *input.DeployedScript
+	if input.DeployedCode != nil {
+		c.DeployedCode = *input.DeployedCode
 	}
 
 	s.contracts[input.ID] = c
@@ -909,7 +909,7 @@ func (s *Store) ResetProjectState(newDeltas []delta.Delta, proj *model.InternalP
 			continue
 		}
 
-		contract.DeployedScript = ""
+		contract.DeployedCode = ""
 
 		s.contracts[contractID] = contract
 	}

--- a/storage/memory/store.go
+++ b/storage/memory/store.go
@@ -432,6 +432,10 @@ func (s *Store) UpdateContract(input model.UpdateContract, con *model.Contract) 
 		c.Script = *input.Script
 	}
 
+	if input.DeployedScript != nil {
+		c.DeployedScript = *input.DeployedScript
+	}
+
 	s.contracts[input.ID] = c
 
 	*con = c

--- a/storage/memory/store.go
+++ b/storage/memory/store.go
@@ -270,14 +270,6 @@ func (s *Store) updateAccount(input model.UpdateAccount, acc *model.InternalAcco
 		return storage.ErrNotFound
 	}
 
-	if input.DraftCode != nil {
-		a.DraftCode = *input.DraftCode
-	}
-
-	if input.DeployedCode != nil {
-		a.DeployedCode = *input.DeployedCode
-	}
-
 	if input.DeployedContracts != nil {
 		a.DeployedContracts = *input.DeployedContracts
 	}
@@ -911,14 +903,13 @@ func (s *Store) ResetProjectState(newDeltas []delta.Delta, proj *model.InternalP
 	s.mut.Lock()
 	defer s.mut.Unlock()
 
-	// clear deployed code from accounts
+	//soe to-do clear/reset deployed scripts from contracts
 
 	for accountID, account := range s.accounts {
 		if account.ProjectID != proj.ID {
 			continue
 		}
 
-		account.DeployedCode = ""
 		account.DeployedContracts = nil
 
 		s.accounts[accountID] = account

--- a/storage/memory/store.go
+++ b/storage/memory/store.go
@@ -903,7 +903,16 @@ func (s *Store) ResetProjectState(newDeltas []delta.Delta, proj *model.InternalP
 	s.mut.Lock()
 	defer s.mut.Unlock()
 
-	//soe to-do clear/reset deployed scripts from contracts
+	// clear/reset deployed scripts from contracts
+	for contractID, contract := range s.contracts {
+		if contract.ProjectID != proj.ID {
+			continue
+		}
+
+		contract.DeployedScript = ""
+
+		s.contracts[contractID] = contract
+	}
 
 	for accountID, account := range s.accounts {
 		if account.ProjectID != proj.ID {

--- a/storage/memory/store.go
+++ b/storage/memory/store.go
@@ -396,10 +396,10 @@ func (s *Store) insertContract(con *model.Contract) error {
 		return err
 	}
 
-	count := len(cons)
-
+	//soe Index means AccountIndex
+	//count := len(cons)
 	// set index to one after last
-	con.Index = count
+	//con.Index = count
 
 	s.contracts[con.ID] = *con
 

--- a/storage/memory/store.go
+++ b/storage/memory/store.go
@@ -388,11 +388,6 @@ func (s *Store) insertContract(con *model.Contract) error {
 		return err
 	}
 
-	//soe Index means AccountIndex
-	//count := len(cons)
-	// set index to one after last
-	//con.Index = count
-
 	s.contracts[con.ID] = *con
 
 	err = s.markProjectUpdatedAt(con.ProjectID)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -36,6 +36,7 @@ type Store interface {
 		proj *model.InternalProject,
 		registerDeltas []delta.Delta,
 		accounts []*model.InternalAccount,
+		contracts []*model.Contract,
 		ttpl []*model.TransactionTemplate,
 		stpl []*model.ScriptTemplate,
 	) error
@@ -56,6 +57,12 @@ type Store interface {
 	) error
 	GetAccountsForProject(projectID uuid.UUID, accs *[]*model.InternalAccount) error
 	DeleteAccount(id model.ProjectChildID) error
+
+	InsertContract(con *model.Contract) error
+	UpdateContract(input model.UpdateContract, con *model.Contract) error
+	GetContract(id model.ProjectChildID, con *model.Contract) error
+	GetContractsForProject(projectID uuid.UUID, cons *[]*model.Contract) error
+	DeleteContract(id model.ProjectChildID) error
 
 	InsertTransactionTemplate(tpl *model.TransactionTemplate) error
 	UpdateTransactionTemplate(input model.UpdateTransactionTemplate, tpl *model.TransactionTemplate) error


### PR DESCRIPTION
## Description

This PR is for Flipfest issue 21.

- [x] frontend: project default loading with multiple contracts per account 
- [x] frontend: contracts can be added, edited, deployed and deleted 
- [x] backend: support the above interactions

Check out the [demo video](https://youtu.be/PEB1A5GRAbA)

## To-dos and known-issues
- [x] export project folder
- [x] remove comments starting with '//soe'
- [x] fix Cadence code check for transactions as contract [declarations are not detected](https://user-images.githubusercontent.com/81572453/140640705-79b27723-0a13-444b-b7cb-5bb78b3ae1b0.png) - [fixed now](https://github.com/soetop/flow-playground/commit/ce3efb7d3e6c6b59492cea1093f88f436bc35a71)
- [x] write test coverage
   - [initial coverage](https://github.com/onflow/flow-playground-api/pull/14/commits/974ff2a9f9d3bd1bba7525cdc3dfbe30af797104)
   - [more coverage](https://github.com/soetop/flow-playground-api/commit/ee108a56cedd24c944963717d98a59c47c619b71)
- [x] code [documentation](https://laser-teal-a79.notion.site/Notes-for-changes-Flipfest-21-b2c49263e87a4551b57826070fe566a6)

## Submission Links & Documents

_Backend_: flow-playground-api has been forked and work is done on [flip-21 branch](https://github.com/soetop/flow-playground-api/tree/flip-21)

Run datastore emulator first
```
  gcloud beta emulators datastore start
```

Then run the server
```
  make run-datastore
```


_Frontend_: flow-playground has been forked and work is done on [flip-21 branch](https://github.com/soetop/flow-playground/tree/flip-21)

```
  npm install
  npm run start
```