### PR TITLE
Remove unused indexes.

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -34,9 +34,9 @@ type InternalProject struct {
 	Secret                    uuid.UUID
 	PublicID                  uuid.UUID
 	ParentID                  *uuid.UUID
-	Title                     string
-	Description               string
-	Readme                    string
+	Title                     string `datastore:",noindex"`
+	Description               string `datastore:",noindex"`
+	Readme                    string `datastore:",noindex"`
 	Seed                      int
 	TransactionCount          int
 	TransactionExecutionCount int

--- a/model/project.go
+++ b/model/project.go
@@ -272,9 +272,9 @@ type Project struct {
 	ParentID    *uuid.UUID
 	Seed        int
 	Version     *semver.Version
-	Title       string
-	Description string
-	Readme      string
+	Title       string `datastore:",noindex"`
+	Description string `datastore:",noindex"`
+	Readme      string `datastore:",noindex"`
 	Persist     bool
 	Mutable     bool
 }


### PR DESCRIPTION
## Description

Google cloud datastore constrains entity properties that are indexed to `1,500 bytes`.  Unindexed properties are constrained to `~1.2mb`, This PR removes the index from the project README property, so larger files (up to 1.2mb) can be saved.

Limitations docs: https://cloud.google.com/datastore/docs/concepts/limits
Property notation doc: https://cloud.google.com/datastore/docs/concepts/indexes#datastore-datastore-properties-go



______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

