### PR TITLE
Add sentry capture exception to resolver methods

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -20,7 +20,6 @@ package client
 
 import (
 	"encoding/json"
-	"github.com/getsentry/sentry-go"
 )
 
 // RawJsonError is a json formatted error from a GraphQL server.
@@ -29,6 +28,5 @@ type RawJsonError struct {
 }
 
 func (r RawJsonError) Error() string {
-	sentry.CaptureMessage(string(r.RawMessage))
 	return string(r.RawMessage)
 }

--- a/client/errors.go
+++ b/client/errors.go
@@ -18,7 +18,10 @@
 
 package client
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"github.com/getsentry/sentry-go"
+)
 
 // RawJsonError is a json formatted error from a GraphQL server.
 type RawJsonError struct {
@@ -26,5 +29,6 @@ type RawJsonError struct {
 }
 
 func (r RawJsonError) Error() string {
+	sentry.CaptureMessage(string(r.RawMessage))
 	return string(r.RawMessage)
 }

--- a/compute/errors.go
+++ b/compute/errors.go
@@ -20,6 +20,7 @@ package compute
 
 import (
 	"errors"
+	"github.com/getsentry/sentry-go"
 
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/ast"
@@ -29,6 +30,7 @@ import (
 )
 
 func ExtractProgramErrors(err error) (result []model.ProgramError) {
+	sentry.CaptureException(err)
 	// set the default return value
 	result = []model.ProgramError{
 		convertProgramError(err),

--- a/compute/errors.go
+++ b/compute/errors.go
@@ -20,8 +20,6 @@ package compute
 
 import (
 	"errors"
-	"github.com/getsentry/sentry-go"
-
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/ast"
 	runtimeErrors "github.com/onflow/cadence/runtime/errors"
@@ -30,7 +28,6 @@ import (
 )
 
 func ExtractProgramErrors(err error) (result []model.ProgramError) {
-	sentry.CaptureException(err)
 	// set the default return value
 	result = []model.ProgramError{
 		convertProgramError(err),

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/go-chi/chi v3.3.2+incompatible
 	github.com/go-chi/render v1.0.1
 	github.com/google/uuid v1.3.0
+	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/sessions v1.2.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/golang-lru v0.5.4

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/go-chi/chi v3.3.2+incompatible
 	github.com/go-chi/render v1.0.1
 	github.com/google/uuid v1.3.0
+	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/sessions v1.2.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/golang-lru v0.5.4
@@ -67,7 +68,6 @@ require (
 	github.com/google/go-cmp v0.5.7 // indirect
 	github.com/googleapis/gax-go/v2 v2.1.1 // indirect
 	github.com/gorilla/css v1.0.0 // indirect
-	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gorilla/securecookie v1.1.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/go-chi/chi v3.3.2+incompatible
 	github.com/go-chi/render v1.0.1
 	github.com/google/uuid v1.3.0
-	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/sessions v1.2.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/golang-lru v0.5.4

--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,7 @@ require (
 	github.com/google/go-cmp v0.5.7 // indirect
 	github.com/googleapis/gax-go/v2 v2.1.1 // indirect
 	github.com/gorilla/css v1.0.0 // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gorilla/securecookie v1.1.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -370,6 +370,8 @@ github.com/gorilla/context v0.0.0-20160226214623-1ea25387ff6f/go.mod h1:kBGZzfjB
 github.com/gorilla/css v1.0.0 h1:BQqNyPTi50JCFMTw/b67hByjMVXZRwGha6wxVGkeihY=
 github.com/gorilla/css v1.0.0/go.mod h1:Dn721qIggHpt4+EFCcTLTU/vk5ySda2ReITrtgBl60c=
 github.com/gorilla/mux v1.6.1/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.0 h1:S7P+1Hm5V/AT9cjEcUD5uDaQSX0OE577aCXgoaKpYbQ=

--- a/go.sum
+++ b/go.sum
@@ -182,9 +182,11 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.1 h1:r/myEWzV9lfsM1tFLgDyu0atFtJ1fXn261LKYj/3DxU=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 h1:y5HC9v93H5EPKqaS1UYVg1uYah5Xf51mBfIoWehClUQ=
@@ -370,6 +372,8 @@ github.com/gorilla/context v0.0.0-20160226214623-1ea25387ff6f/go.mod h1:kBGZzfjB
 github.com/gorilla/css v1.0.0 h1:BQqNyPTi50JCFMTw/b67hByjMVXZRwGha6wxVGkeihY=
 github.com/gorilla/css v1.0.0/go.mod h1:Dn721qIggHpt4+EFCcTLTU/vk5ySda2ReITrtgBl60c=
 github.com/gorilla/mux v1.6.1/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.0 h1:S7P+1Hm5V/AT9cjEcUD5uDaQSX0OE577aCXgoaKpYbQ=
@@ -712,8 +716,10 @@ github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521/go.mod h1:RvLn4FgxWubr
 github.com/rs/xid v1.3.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.26.1 h1:/ihwxqH+4z8UxyI70wM1z9yCvkWcfz/a3mj48k/Zngc=
 github.com/rs/zerolog v1.26.1/go.mod h1:/wSSJWX7lVrsOwlbyTRSOJvqRlc+WjWlfes+CiJ+tmc=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sagikazarmark/crypt v0.3.0/go.mod h1:uD/D+6UF4SrIR1uGEv7bBNkNqLGqUr43MRiaGWX1Nig=
@@ -800,6 +806,7 @@ github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVM
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+github.com/urfave/cli v1.22.1 h1:+mkCCcOFKPnCmVYVcURKps1Xe+3zP90gSYGNfRkjoIY=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vektah/dataloaden v0.2.1-0.20190515034641-a19b9a6e7c9e/go.mod h1:/HUdMve7rvxZma+2ZELQeNh88+003LL7Pf/CZ089j8U=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=

--- a/go.sum
+++ b/go.sum
@@ -370,8 +370,6 @@ github.com/gorilla/context v0.0.0-20160226214623-1ea25387ff6f/go.mod h1:kBGZzfjB
 github.com/gorilla/css v1.0.0 h1:BQqNyPTi50JCFMTw/b67hByjMVXZRwGha6wxVGkeihY=
 github.com/gorilla/css v1.0.0/go.mod h1:Dn721qIggHpt4+EFCcTLTU/vk5ySda2ReITrtgBl60c=
 github.com/gorilla/mux v1.6.1/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
-github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
-github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.0 h1:S7P+1Hm5V/AT9cjEcUD5uDaQSX0OE577aCXgoaKpYbQ=

--- a/go.sum
+++ b/go.sum
@@ -182,11 +182,9 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/cpuguy83/go-md2man/v2 v2.0.1 h1:r/myEWzV9lfsM1tFLgDyu0atFtJ1fXn261LKYj/3DxU=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 h1:y5HC9v93H5EPKqaS1UYVg1uYah5Xf51mBfIoWehClUQ=
@@ -716,10 +714,8 @@ github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521/go.mod h1:RvLn4FgxWubr
 github.com/rs/xid v1.3.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.26.1 h1:/ihwxqH+4z8UxyI70wM1z9yCvkWcfz/a3mj48k/Zngc=
 github.com/rs/zerolog v1.26.1/go.mod h1:/wSSJWX7lVrsOwlbyTRSOJvqRlc+WjWlfes+CiJ+tmc=
-github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sagikazarmark/crypt v0.3.0/go.mod h1:uD/D+6UF4SrIR1uGEv7bBNkNqLGqUr43MRiaGWX1Nig=
@@ -806,7 +802,6 @@ github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVM
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
-github.com/urfave/cli v1.22.1 h1:+mkCCcOFKPnCmVYVcURKps1Xe+3zP90gSYGNfRkjoIY=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vektah/dataloaden v0.2.1-0.20190515034641-a19b9a6e7c9e/go.mod h1:/HUdMve7rvxZma+2ZELQeNh88+003LL7Pf/CZ089j8U=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=

--- a/handler.go
+++ b/handler.go
@@ -29,7 +29,6 @@ import (
 )
 
 func GraphQLHandler(resolver *Resolver, options ...handler.Option) http.HandlerFunc {
-	// init crash reporting
 	defer sentry.Flush(2 * time.Second)
 	defer sentry.Recover()
 

--- a/handler.go
+++ b/handler.go
@@ -40,8 +40,6 @@ func GraphQLHandler(resolver *Resolver, options ...handler.Option) http.HandlerF
 		}),
 	)
 
-	panic("testing panic in handler.go")
-
 	return handler.GraphQL(
 		NewExecutableSchema(Config{Resolvers: resolver}),
 		options...,

--- a/handler.go
+++ b/handler.go
@@ -21,13 +21,17 @@ package playground
 import (
 	"context"
 	"fmt"
+	"github.com/99designs/gqlgen/handler"
+	"github.com/getsentry/sentry-go"
 	"net/http"
 	"runtime/debug"
-
-	"github.com/99designs/gqlgen/handler"
+	"time"
 )
 
 func GraphQLHandler(resolver *Resolver, options ...handler.Option) http.HandlerFunc {
+	// init crash reporting
+	defer sentry.Flush(2 * time.Second)
+	defer sentry.Recover()
 
 	options = append(
 		options,
@@ -35,6 +39,8 @@ func GraphQLHandler(resolver *Resolver, options ...handler.Option) http.HandlerF
 			return fmt.Errorf("panic: %s\n\n%s", err, string(debug.Stack()))
 		}),
 	)
+
+	panic("testing panic in handler.go")
 
 	return handler.GraphQL(
 		NewExecutableSchema(Config{Resolvers: resolver}),

--- a/handler.go
+++ b/handler.go
@@ -22,16 +22,11 @@ import (
 	"context"
 	"fmt"
 	"github.com/99designs/gqlgen/handler"
-	"github.com/getsentry/sentry-go"
 	"net/http"
 	"runtime/debug"
-	"time"
 )
 
 func GraphQLHandler(resolver *Resolver, options ...handler.Option) http.HandlerFunc {
-	defer sentry.Flush(2 * time.Second)
-	defer sentry.Recover()
-
 	options = append(
 		options,
 		handler.RecoverFunc(func(ctx context.Context, err interface{}) (userMessage error) {

--- a/middleware/errors/errors.go
+++ b/middleware/errors/errors.go
@@ -32,7 +32,7 @@ var (
 	errLoggerFieldsCtxKey = gqlErrCtxKeyType("error-logger-fields")
 )
 
-// Middleware is a catch-all middleware for GLQ request errors.
+// Middleware is a catch-all middleware for GQL request errors.
 func Middleware(entry *logrus.Entry) graphql.RequestMiddleware {
 	return func(ctx context.Context, next func(ctx context.Context) []byte) []byte {
 		debugFields := logrus.Fields{}

--- a/middleware/monitoring/sentry.go
+++ b/middleware/monitoring/sentry.go
@@ -20,11 +20,9 @@ package monitoring
 
 import (
 	sentryhttp "github.com/getsentry/sentry-go/http"
-	"net/http"
+	"github.com/gorilla/mux"
 )
 
-func Middleware() func(http.Handler) http.Handler {
-	sentryHandler := sentryhttp.New(sentryhttp.Options{})
-
-	return sentryHandler.Handle
+func Middleware() mux.MiddlewareFunc {
+	return sentryhttp.New(sentryhttp.Options{}).Handle
 }

--- a/middleware/monitoring/sentry.go
+++ b/middleware/monitoring/sentry.go
@@ -20,9 +20,11 @@ package monitoring
 
 import (
 	sentryhttp "github.com/getsentry/sentry-go/http"
-	"github.com/gorilla/mux"
+	"net/http"
 )
 
-func Middleware() mux.MiddlewareFunc {
-	return sentryhttp.New(sentryhttp.Options{}).Handle
+func Middleware() func(http.Handler) http.Handler {
+	sentryHandler := sentryhttp.New(sentryhttp.Options{})
+
+	return sentryHandler.Handle
 }

--- a/middleware/monitoring/sentry.go
+++ b/middleware/monitoring/sentry.go
@@ -1,0 +1,10 @@
+package monitoring
+
+import (
+	sentryhttp "github.com/getsentry/sentry-go/http"
+	"github.com/gorilla/mux"
+)
+
+func Middleware() mux.MiddlewareFunc {
+	return sentryhttp.New(sentryhttp.Options{}).Handle
+}

--- a/middleware/monitoring/sentry.go
+++ b/middleware/monitoring/sentry.go
@@ -1,3 +1,21 @@
+/*
+ * Flow Playground
+ *
+ * Copyright 2019-2021 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package monitoring
 
 import (

--- a/model/user.go
+++ b/model/user.go
@@ -20,6 +20,7 @@ package model
 
 import (
 	"cloud.google.com/go/datastore"
+	"github.com/getsentry/sentry-go"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
@@ -38,11 +39,14 @@ func (u *User) Load(ps []datastore.Property) error {
 	}{}
 
 	if err := datastore.LoadStruct(&tmp, ps); err != nil {
+		sentry.CaptureException(err)
 		return err
 	}
 
 	if err := u.ID.UnmarshalText([]byte(tmp.ID)); err != nil {
-		return errors.Wrap(err, "failed to decode UUID")
+		wrappedErr := errors.Wrap(err, "failed to decode UUID")
+		sentry.CaptureException(wrappedErr)
+		return wrappedErr
 	}
 
 	return nil

--- a/model/user.go
+++ b/model/user.go
@@ -20,7 +20,6 @@ package model
 
 import (
 	"cloud.google.com/go/datastore"
-	"github.com/getsentry/sentry-go"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
@@ -39,14 +38,11 @@ func (u *User) Load(ps []datastore.Property) error {
 	}{}
 
 	if err := datastore.LoadStruct(&tmp, ps); err != nil {
-		sentry.CaptureException(err)
 		return err
 	}
 
 	if err := u.ID.UnmarshalText([]byte(tmp.ID)); err != nil {
-		wrappedErr := errors.Wrap(err, "failed to decode UUID")
-		sentry.CaptureException(wrappedErr)
-		return wrappedErr
+		return errors.Wrap(err, "failed to decode UUID")
 	}
 
 	return nil

--- a/resolver.go
+++ b/resolver.go
@@ -22,7 +22,12 @@ import (
 	"context"
 	"fmt"
 	"github.com/Masterminds/semver"
-	"github.com/getsentry/sentry-go"
+	"github.com/dapperlabs/flow-playground-api/auth"
+	"github.com/dapperlabs/flow-playground-api/compute"
+	"github.com/dapperlabs/flow-playground-api/controller"
+	"github.com/dapperlabs/flow-playground-api/migrate"
+	"github.com/dapperlabs/flow-playground-api/model"
+	"github.com/dapperlabs/flow-playground-api/storage"
 	"github.com/google/uuid"
 	"github.com/onflow/cadence"
 	jsoncdc "github.com/onflow/cadence/encoding/json"
@@ -33,14 +38,6 @@ import (
 	"github.com/onflow/flow-go-sdk/templates"
 	flowgo "github.com/onflow/flow-go/model/flow"
 	"github.com/pkg/errors"
-	"time"
-
-	"github.com/dapperlabs/flow-playground-api/auth"
-	"github.com/dapperlabs/flow-playground-api/compute"
-	"github.com/dapperlabs/flow-playground-api/controller"
-	"github.com/dapperlabs/flow-playground-api/migrate"
-	"github.com/dapperlabs/flow-playground-api/model"
-	"github.com/dapperlabs/flow-playground-api/storage"
 )
 
 const MaxAccounts = 5
@@ -62,9 +59,6 @@ func NewResolver(
 	computer *compute.Computer,
 	auth *auth.Authenticator,
 ) *Resolver {
-	defer sentry.Flush(2 * time.Second)
-	defer sentry.Recover()
-
 	projects := controller.NewProjects(version, store, computer, MaxAccounts)
 	scripts := controller.NewScripts(store, computer)
 	migrator := migrate.NewMigrator(projects)

--- a/resolver.go
+++ b/resolver.go
@@ -622,7 +622,6 @@ func (r *projectResolver) ScriptExecutions(ctx context.Context, obj *model.Proje
 type queryResolver struct{ *Resolver }
 
 func (r *queryResolver) PlaygroundInfo(ctx context.Context) (*model.PlaygroundInfo, error) {
-	panic("Testing API")
 	return &model.PlaygroundInfo{
 		APIVersion:     *r.version,
 		CadenceVersion: *semver.MustParse(cadence.Version),

--- a/resolver.go
+++ b/resolver.go
@@ -208,7 +208,7 @@ func (r *mutationResolver) UpdateAccount(ctx context.Context, input model.Update
 	}
 
 	if result.Err != nil {
-		return nil, errors.Wrap(err, "failed to deploy account code")
+		return nil, errors.Wrap(result.Err, "failed to deploy account code")
 	}
 
 	states, err := r.getAccountStates(proj.ID, result.States)
@@ -565,7 +565,7 @@ func (r *projectResolver) Accounts(ctx context.Context, obj *model.Project) ([]*
 
 	err := r.store.GetAccountsForProject(obj.ID, &accs)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get project")
+		return nil, errors.Wrap(err, "failed to get accounts")
 	}
 
 	exportedAccs := make([]*model.Account, len(accs))

--- a/server/server.go
+++ b/server/server.go
@@ -21,6 +21,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/dapperlabs/flow-playground-api/middleware/monitoring"
 	"log"
 	"net/http"
 	"strings"
@@ -128,7 +129,7 @@ func main() {
 		if err != nil {
 			// If datastore is expected, panic when we can't init
 			sentry.CaptureException(err)
-			panic(err)
+			log.Fatal(err)
 		}
 	} else {
 		store = memory.NewStore()
@@ -137,7 +138,7 @@ func main() {
 	computer, err := compute.NewComputer(zerolog.Nop(), conf.LedgerCacheSize)
 	if err != nil {
 		sentry.CaptureException(err)
-		panic(err)
+		log.Fatal(err)
 	}
 
 	sessionAuthKey := []byte(conf.SessionAuthKey)
@@ -210,6 +211,8 @@ func main() {
 
 	router.Handle("/metrics", promhttp.Handler())
 	router.HandleFunc("/ping", ping)
+
+	router.Use(monitoring.Middleware())
 
 	logStartMessage(build.Version())
 

--- a/server/server.go
+++ b/server/server.go
@@ -151,6 +151,7 @@ func main() {
 	prometheus.Register()
 
 	router := chi.NewRouter()
+	router.Use(monitoring.Middleware())
 
 	if conf.Debug {
 		router.Handle("/", handler.Playground("GraphQL playground", "/query"))
@@ -211,8 +212,6 @@ func main() {
 
 	router.Handle("/metrics", promhttp.Handler())
 	router.HandleFunc("/ping", ping)
-
-	router.Use(monitoring.Middleware())
 
 	logStartMessage(build.Version())
 

--- a/server/server.go
+++ b/server/server.go
@@ -179,6 +179,7 @@ func main() {
 
 		r.Use(httpcontext.Middleware())
 		r.Use(sessions.Middleware(cookieStore))
+		r.Use(monitoring.Middleware())
 
 		r.Handle(
 			"/",

--- a/server/server.go
+++ b/server/server.go
@@ -91,8 +91,9 @@ func main() {
 	}
 
 	err := sentry.Init(sentry.ClientOptions{
-		Dsn:   sentryConf.Dsn,
-		Debug: sentryConf.Debug,
+		Dsn:              sentryConf.Dsn,
+		Debug:            sentryConf.Debug,
+		AttachStacktrace: true,
 	})
 
 	if err != nil {
@@ -100,11 +101,11 @@ func main() {
 	}
 
 	defer sentry.Flush(2 * time.Second)
+	defer sentry.Recover()
 
 	var conf Config
 
 	if err := envconfig.Process("FLOW", &conf); err != nil {
-		sentry.CaptureException(err)
 		log.Fatal(err)
 	}
 
@@ -114,7 +115,6 @@ func main() {
 		var datastoreConf DatastoreConfig
 
 		if err := envconfig.Process("FLOW_DATASTORE", &datastoreConf); err != nil {
-			sentry.CaptureException(err)
 			log.Fatal(err)
 		}
 
@@ -127,8 +127,6 @@ func main() {
 			},
 		)
 		if err != nil {
-			// If datastore is expected, panic when we can't init
-			sentry.CaptureException(err)
 			log.Fatal(err)
 		}
 	} else {
@@ -137,7 +135,6 @@ func main() {
 
 	computer, err := compute.NewComputer(zerolog.Nop(), conf.LedgerCacheSize)
 	if err != nil {
-		sentry.CaptureException(err)
 		log.Fatal(err)
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -76,8 +76,8 @@ type DatastoreConfig struct {
 }
 
 type SentryConfig struct {
-	Dsn		string	`default:"https://e8ff473e48aa4962b1a518411489ec5d@o114654.ingest.sentry.io/6398442"`
-	Debug	bool	`default:"true"`
+	Dsn   string `default:"https://e8ff473e48aa4962b1a518411489ec5d@o114654.ingest.sentry.io/6398442"`
+	Debug bool   `default:"true"`
 }
 
 const sessionName = "flow-playground"
@@ -90,8 +90,8 @@ func main() {
 	}
 
 	err := sentry.Init(sentry.ClientOptions{
-		Dsn: 			sentryConf.Dsn,
-		Debug: 			sentryConf.Debug,
+		Dsn:   sentryConf.Dsn,
+		Debug: sentryConf.Debug,
 	})
 
 	if err != nil {
@@ -99,10 +99,11 @@ func main() {
 	}
 
 	defer sentry.Flush(2 * time.Second)
-	
+
 	var conf Config
 
 	if err := envconfig.Process("FLOW", &conf); err != nil {
+		sentry.CaptureException(err)
 		log.Fatal(err)
 	}
 
@@ -112,6 +113,7 @@ func main() {
 		var datastoreConf DatastoreConfig
 
 		if err := envconfig.Process("FLOW_DATASTORE", &datastoreConf); err != nil {
+			sentry.CaptureException(err)
 			log.Fatal(err)
 		}
 
@@ -125,6 +127,7 @@ func main() {
 		)
 		if err != nil {
 			// If datastore is expected, panic when we can't init
+			sentry.CaptureException(err)
 			panic(err)
 		}
 	} else {
@@ -133,6 +136,7 @@ func main() {
 
 	computer, err := compute.NewComputer(zerolog.Nop(), conf.LedgerCacheSize)
 	if err != nil {
+		sentry.CaptureException(err)
 		panic(err)
 	}
 


### PR DESCRIPTION
Closes: https://github.com/onflow/next-docs-v1/issues/461

## Description
Enabling sentry reporting, which is currently all ignored due to Middleware. Unfortunately, logrus doesn't have an updated package for sentry integration, so the easiest solution seems to be notifying Sentry at the highest level of error (resolver methods)

Alternative solution:
We could try integrating sentry-go and logrus middleware using something like this: https://github.com/onrik/logrus. I am currently trying to make this work locally.
______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

