### PR TITLE
Bugfix update account

### DIFF
--- a/blockchain/projects.go
+++ b/blockchain/projects.go
@@ -158,6 +158,7 @@ func (s *Projects) CreateInitialAccounts(projectID uuid.UUID) ([]*model.Internal
 				ProjectID: projectID,
 			},
 			Address: account.Address,
+			Index:   i,
 		}
 	}
 

--- a/controller/accounts.go
+++ b/controller/accounts.go
@@ -19,8 +19,6 @@
 package controller
 
 import (
-	"fmt"
-
 	"github.com/dapperlabs/flow-playground-api/blockchain"
 	"github.com/dapperlabs/flow-playground-api/model"
 	"github.com/dapperlabs/flow-playground-api/storage"
@@ -88,7 +86,7 @@ func (a *Accounts) Update(input model.UpdateAccount) (*model.Account, error) {
 	var acc model.InternalAccount
 
 	// if we provided draft code then just do a storage update of an account
-	if input.DraftCode != nil {
+	if input.DeployedCode == nil {
 		err := a.store.UpdateAccount(input, &acc)
 		if err != nil {
 			return nil, err
@@ -100,11 +98,6 @@ func (a *Accounts) Update(input model.UpdateAccount) (*model.Account, error) {
 	err := a.store.GetAccount(model.NewProjectChildID(input.ID, input.ProjectID), &acc)
 	if err != nil {
 		return nil, err
-	}
-
-	// if deployed code is not provided fail, else continue and deploy new contracts
-	if input.DeployedCode == nil {
-		return nil, fmt.Errorf("must provide either deployed code or draft code for update")
 	}
 
 	account, err := a.blockchain.GetAccount(input.ProjectID, acc.Address)

--- a/model/account.go
+++ b/model/account.go
@@ -42,6 +42,7 @@ func (a *InternalAccount) Load(ps []datastore.Property) error {
 		ProjectID string
 		Address   []byte
 		DraftCode string
+		Index     int
 	}{}
 
 	if err := datastore.LoadStruct(&tmp, ps); err != nil {
@@ -80,6 +81,10 @@ func (a *InternalAccount) Save() ([]datastore.Property, error) {
 		{
 			Name:  "DraftCode",
 			Value: a.DraftCode,
+		},
+		{
+			Name:  "Index",
+			Value: a.Index,
 		},
 	}, nil
 }

--- a/model/account.go
+++ b/model/account.go
@@ -29,6 +29,7 @@ type InternalAccount struct {
 	ProjectChildID
 	Address   Address
 	DraftCode string
+	Index     int
 }
 
 func (a *InternalAccount) NameKey() *datastore.Key {

--- a/model/account.go
+++ b/model/account.go
@@ -58,7 +58,7 @@ func (a *InternalAccount) Load(ps []datastore.Property) error {
 	}
 
 	copy(a.Address[:], tmp.Address[:])
-
+	a.Index = tmp.Index
 	a.DraftCode = tmp.DraftCode
 
 	return nil

--- a/storage/datastore/store.go
+++ b/storage/datastore/store.go
@@ -278,7 +278,7 @@ func (d *Datastore) ResetProjectState(proj *model.InternalProject) error {
 		proj.TransactionCount = 0
 		proj.UpdatedAt = time.Now()
 
-		_, err = tx.Put(proj.NameKey(), &proj)
+		_, err = tx.Put(proj.NameKey(), proj)
 		if err != nil {
 			return err
 		}

--- a/storage/memory/store.go
+++ b/storage/memory/store.go
@@ -288,7 +288,7 @@ func (s *Store) getAccountsForProject(projectID uuid.UUID, accs *[]*model.Intern
 
 	// sort results by index
 	sort.Slice(res, func(i, j int) bool {
-		return res[i].Address[len(res[i].Address)-1] < res[j].Address[len(res[j].Address)-1]
+		return res[i].Index < res[j].Index
 	})
 
 	*accs = res


### PR DESCRIPTION
This PR reintroduces the index on the internal account for better performance on datastore indexing. It also fixes a logical bug on the update of an account deployed contract and adds the test for it.
______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

