### PR TITLE
Datastore on-demand migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test:
 
 .PHONY: test-datastore
 test-datastore:
-	DATASTORE_EMULATOR_HOST=localhost:8081 FLOW_STORAGEBACKEND=datastore GO111MODULE=on go test ./...
+	DATASTORE_EMULATOR_HOST=localhost:8081 FLOW_STORAGEBACKEND=datastore GO111MODULE=on go test -v ./...
 
 .PHONY: test-migration
 test-migration:

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,11 @@ test:
 test-datastore:
 	DATASTORE_EMULATOR_HOST=localhost:8081 FLOW_STORAGEBACKEND=datastore GO111MODULE=on go test ./...
 
+.PHONY: test-migration
+test-migration:
+	DATASTORE_EMULATOR_HOST=localhost:8081 FLOW_STORAGEBACKEND=datastore GO111MODULE=on go test ./migrate/... -run Test_MigrationV0_12_0
+
+
 .PHONY: run
 run:
 	FLOW_DEBUG=true \

--- a/adapter/address.go
+++ b/adapter/address.go
@@ -37,8 +37,8 @@ import (
 const numberOfServiceAccounts = 4
 const addressLength = 8
 
-// contentAddressFromAPI converts addresses found in content from the user input.
-func contentAddressFromAPI(input string) string {
+// ContentAddressFromAPI converts addresses found in content from the user input.
+func ContentAddressFromAPI(input string) string {
 	return contentAdapter(input, true)
 }
 
@@ -69,8 +69,8 @@ func contentAdapter(input string, fromInput bool) string {
 	return input
 }
 
-// addressFromAPI converts the address from the user input and shifts it for number of service accounts.
-func addressFromAPI(address model.Address) model.Address {
+// AddressFromAPI converts the address from the user input and shifts it for number of service accounts.
+func AddressFromAPI(address model.Address) model.Address {
 	var b model.Address // create a copy
 	copy(b[:], address[:])
 	b[len(b)-1] = b[len(b)-1] + numberOfServiceAccounts
@@ -79,7 +79,7 @@ func addressFromAPI(address model.Address) model.Address {
 
 func addressesFromAPI(addresses []model.Address) []model.Address {
 	for i, address := range addresses {
-		addresses[i] = addressFromAPI(address)
+		addresses[i] = AddressFromAPI(address)
 	}
 	return addresses
 }

--- a/adapter/address_test.go
+++ b/adapter/address_test.go
@@ -81,7 +81,7 @@ func Test_AddressAdapter(t *testing.T) {
 		}
 
 		for _, vector := range testVectors {
-			out := addressFromAPI(vector[0])
+			out := AddressFromAPI(vector[0])
 			assert.Equal(t, vector[1], out)
 		}
 	})

--- a/adapter/models.go
+++ b/adapter/models.go
@@ -23,11 +23,11 @@ import "github.com/dapperlabs/flow-playground-api/model"
 // models adapters compose different adapters in a single adapter.
 
 func TransactionFromAPI(tx model.NewTransactionExecution) model.NewTransactionExecution {
-	tx.Script = contentAddressFromAPI(tx.Script)
+	tx.Script = ContentAddressFromAPI(tx.Script)
 	tx.Signers = addressesFromAPI(tx.Signers)
 
 	for i, arg := range tx.Arguments {
-		tx.Arguments[i] = contentAddressFromAPI(arg)
+		tx.Arguments[i] = ContentAddressFromAPI(arg)
 	}
 
 	return tx
@@ -38,7 +38,7 @@ func TransactionToAPI(tx *model.TransactionExecution) *model.TransactionExecutio
 	tx.Signers = addressesToAPI(tx.Signers)
 
 	for i, arg := range tx.Arguments {
-		tx.Arguments[i] = contentAddressFromAPI(arg)
+		tx.Arguments[i] = ContentAddressFromAPI(arg)
 	}
 
 	for i, e := range tx.Events {
@@ -62,9 +62,9 @@ func TransactionsToAPI(txs []*model.TransactionExecution) []*model.TransactionEx
 }
 
 func ScriptFromAPI(script model.NewScriptExecution) model.NewScriptExecution {
-	script.Script = contentAddressFromAPI(script.Script)
+	script.Script = ContentAddressFromAPI(script.Script)
 	for i, a := range script.Arguments {
-		script.Arguments[i] = contentAddressFromAPI(a)
+		script.Arguments[i] = ContentAddressFromAPI(a)
 	}
 	return script
 }
@@ -103,7 +103,7 @@ func AccountsToAPI(accounts []*model.Account) []*model.Account {
 
 func AccountFromAPI(account model.UpdateAccount) model.UpdateAccount {
 	if account.DeployedCode != nil {
-		adaptedCode := contentAddressFromAPI(*account.DeployedCode)
+		adaptedCode := ContentAddressFromAPI(*account.DeployedCode)
 		account.DeployedCode = &adaptedCode
 	}
 	return account

--- a/adapter/state.go
+++ b/adapter/state.go
@@ -48,5 +48,3 @@ func stateToAPI(state string) string {
 	adaptedState, _ := json.Marshal(accState)
 	return string(adaptedState)
 }
-
-// todo remove fee vaults

--- a/blockchain/projects.go
+++ b/blockchain/projects.go
@@ -224,9 +224,7 @@ func (s *Projects) getAccount(projectID uuid.UUID, address model.Address) (*mode
 		return nil, err
 	}
 
-	addr := address.ToFlowAddress()
-
-	flowAccount, store, err := emulator.getAccount(addr)
+	flowAccount, store, err := emulator.getAccount(address.ToFlowAddress())
 	if err != nil {
 		return nil, err
 	}

--- a/blockchain/projects.go
+++ b/blockchain/projects.go
@@ -158,6 +158,7 @@ func (s *Projects) CreateInitialAccounts(projectID uuid.UUID) ([]*model.Internal
 				ProjectID: projectID,
 			},
 			Address: account.Address,
+			Index:   i,
 		}
 	}
 

--- a/blockchain/projects_test.go
+++ b/blockchain/projects_test.go
@@ -386,6 +386,7 @@ func Test_AccountCreation(t *testing.T) {
 		assert.True(t, strings.Contains(executions[0].Script, "AuthAccount(payer: signer)"))
 	})
 
+	// todo multiple account creations no reset cache - is saving emulator to cache after modifications needed
 	t.Run("multiple account creations, reset cache", func(t *testing.T) {
 		projects, store, proj, _ := newWithSeededProject()
 

--- a/controller/accounts.go
+++ b/controller/accounts.go
@@ -112,7 +112,7 @@ func (a *Accounts) Update(input model.UpdateAccount) (*model.Account, error) {
 			return nil, err
 		}
 
-		err = a.blockchain.Reset(&proj)
+		_, err = a.blockchain.Reset(&proj)
 		if err != nil {
 			return nil, err
 		}

--- a/controller/accounts.go
+++ b/controller/accounts.go
@@ -19,8 +19,6 @@
 package controller
 
 import (
-	"fmt"
-
 	"github.com/dapperlabs/flow-playground-api/blockchain"
 	"github.com/dapperlabs/flow-playground-api/model"
 	"github.com/dapperlabs/flow-playground-api/storage"
@@ -88,7 +86,7 @@ func (a *Accounts) Update(input model.UpdateAccount) (*model.Account, error) {
 	var acc model.InternalAccount
 
 	// if we provided draft code then just do a storage update of an account
-	if input.DraftCode != nil {
+	if input.DeployedCode == nil {
 		err := a.store.UpdateAccount(input, &acc)
 		if err != nil {
 			return nil, err
@@ -100,11 +98,6 @@ func (a *Accounts) Update(input model.UpdateAccount) (*model.Account, error) {
 	err := a.store.GetAccount(model.NewProjectChildID(input.ID, input.ProjectID), &acc)
 	if err != nil {
 		return nil, err
-	}
-
-	// if deployed code is not provided fail, else continue and deploy new contracts
-	if input.DeployedCode == nil {
-		return nil, fmt.Errorf("must provide either deployed code or draft code for update")
 	}
 
 	account, err := a.blockchain.GetAccount(input.ProjectID, acc.Address)

--- a/controller/projects.go
+++ b/controller/projects.go
@@ -147,11 +147,6 @@ func (p *Projects) UpdateVersion(id uuid.UUID, version *semver.Version) error {
 	return nil
 }
 
-func (p *Projects) Reset(proj *model.InternalProject) error {
-	err := p.blockchain.Reset(proj)
-	if err != nil {
-		return err
-	}
-
-	return nil
+func (p *Projects) Reset(proj *model.InternalProject) ([]*model.InternalAccount, error) {
+	return p.blockchain.Reset(proj)
 }

--- a/controller/projects_test.go
+++ b/controller/projects_test.go
@@ -1,3 +1,21 @@
+/*
+ * Flow Playground
+ *
+ * Copyright 2019 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controller
 
 import (

--- a/controller/projects_test.go
+++ b/controller/projects_test.go
@@ -1,0 +1,154 @@
+package controller
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapperlabs/flow-playground-api/blockchain"
+	"github.com/dapperlabs/flow-playground-api/model"
+	"github.com/dapperlabs/flow-playground-api/storage"
+	"github.com/dapperlabs/flow-playground-api/storage/datastore"
+	"github.com/dapperlabs/flow-playground-api/storage/memory"
+	"github.com/golang/groupcache/lru"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func createProjects(t *testing.T) (*Projects, storage.Store, *model.User) {
+	var store storage.Store
+
+	if strings.EqualFold(os.Getenv("FLOW_STORAGEBACKEND"), "datastore") {
+		var err error
+		store, err = datastore.NewDatastore(context.Background(), &datastore.Config{
+			DatastoreProjectID: "dl-flow",
+			DatastoreTimeout:   time.Second * 5,
+		})
+
+		if err != nil {
+			// If datastore is expected, panic when we can't init
+			panic(err)
+		}
+	} else {
+		store = memory.NewStore()
+	}
+
+	user := &model.User{
+		ID: uuid.New(),
+	}
+
+	err := store.InsertUser(user)
+	require.NoError(t, err)
+
+	chain := blockchain.NewProjects(store, lru.New(128), 5)
+	return NewProjects(version, store, chain), store, user
+}
+
+func seedProject(projects *Projects, user *model.User) *model.InternalProject {
+	project, _ := projects.Create(user, model.NewProject{
+		Title:                "test title",
+		Description:          "test description",
+		Readme:               "test readme",
+		Seed:                 1,
+		Accounts:             []string{"a"},
+		TransactionTemplates: nil,
+		ScriptTemplates:      nil,
+	})
+	return project
+}
+
+func Test_CreateProject(t *testing.T) {
+	projects, store, user := createProjects(t)
+
+	t.Run("successful creation", func(t *testing.T) {
+		title := "test title"
+		desc := "test desc"
+		readme := "test readme"
+
+		project, err := projects.Create(user, model.NewProject{
+			Title:                title,
+			Description:          desc,
+			Readme:               readme,
+			Seed:                 1,
+			Accounts:             []string{"a"},
+			TransactionTemplates: nil,
+			ScriptTemplates:      nil,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, title, project.Title)
+		assert.Equal(t, desc, project.Description)
+		assert.Equal(t, readme, project.Readme)
+		assert.Equal(t, 1, project.Seed)
+		assert.False(t, project.Persist)
+		assert.Equal(t, user.ID, project.UserID)
+
+		var dbProj model.InternalProject
+		err = store.GetProject(project.ID, &dbProj)
+		require.NoError(t, err)
+
+		assert.Equal(t, project.Title, dbProj.Title)
+		assert.Equal(t, 5, dbProj.TransactionExecutionCount)
+		assert.Equal(t, 5, dbProj.TransactionCount)
+		assert.Equal(t, 0, dbProj.ScriptTemplateCount)
+		assert.Equal(t, 0, dbProj.TransactionTemplateCount)
+	})
+
+	t.Run("successful update", func(t *testing.T) {
+		projects, store, user := createProjects(t)
+		proj := seedProject(projects, user)
+
+		title := "update title"
+		desc := "update desc"
+		readme := "readme"
+		persist := true
+
+		updated, err := projects.Update(model.UpdateProject{
+			ID:          proj.ID,
+			Title:       &title,
+			Description: &desc,
+			Readme:      &readme,
+			Persist:     &persist,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, desc, updated.Description)
+		assert.Equal(t, title, updated.Title)
+		assert.Equal(t, readme, updated.Readme)
+		assert.Equal(t, persist, updated.Persist)
+
+		var dbProj model.InternalProject
+		err = store.GetProject(proj.ID, &dbProj)
+		require.NoError(t, err)
+		assert.Equal(t, dbProj.ID, updated.ID)
+		assert.Equal(t, dbProj.Description, updated.Description)
+		assert.Equal(t, dbProj.Persist, updated.Persist)
+	})
+
+	t.Run("reset state", func(t *testing.T) {
+		projects, store, user := createProjects(t)
+		proj := seedProject(projects, user)
+
+		err := store.InsertTransactionExecution(&model.TransactionExecution{
+			ProjectChildID: model.ProjectChildID{
+				ID:        uuid.New(),
+				ProjectID: proj.ID,
+			},
+			Index:  6,
+			Script: "test",
+		})
+		require.NoError(t, err)
+
+		accounts, err := projects.Reset(proj)
+		require.Len(t, accounts, 5)
+
+		var dbProj model.InternalProject
+		err = store.GetProject(proj.ID, &dbProj)
+		require.NoError(t, err)
+
+		assert.Equal(t, 5, dbProj.TransactionExecutionCount)
+		assert.Equal(t, 5, dbProj.TransactionCount)
+	})
+}

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -21,8 +21,6 @@ package migrate
 import (
 	"fmt"
 
-	"github.com/dapperlabs/flow-playground-api/storage/datastore"
-
 	"github.com/Masterminds/semver"
 	"github.com/dapperlabs/flow-playground-api/adapter"
 	"github.com/dapperlabs/flow-playground-api/controller"
@@ -68,9 +66,7 @@ func (m *Migrator) MigrateProject(id uuid.UUID, from, to *semver.Version) (bool,
 			return false, errors.Wrapf(err, "failed to migrate project from %s to %s", V0, V0_1_0)
 		}
 	}
-	fmt.Println("migrate v0.12")
 	if from.LessThan(V0_12_0) {
-		fmt.Println("migrating v0.12")
 		err := m.migrateToV0_12_0(id)
 		if err != nil {
 			return false, errors.Wrapf(err, "failed to migrate project from %s to %s", V0, V0_12_0)
@@ -102,7 +98,7 @@ func (m *Migrator) migrateToV0_1_0(id uuid.UUID) error {
 	//  same transaction.
 
 	// Step 1/2
-	err := m.projects.Reset(&proj)
+	_, err := m.projects.Reset(&proj)
 	if err != nil {
 		return errors.Wrap(err, "failed to reset project state")
 	}
@@ -121,27 +117,11 @@ func (m *Migrator) migrateToV0_1_0(id uuid.UUID) error {
 // Steps:
 // - 1. Reset project state recreate initial accounts
 // - 2. Get all accounts for project and update with shifted addresses and removed unused fields
-// - 3. Get all transaction executions and update with shifted addresses in script, arguments and signers
-// - 4. Get all script executions and update with shifted addresses in script and arguments
 func (m *Migrator) migrateToV0_12_0(projectID uuid.UUID) error {
-	fmt.Println("MIGRATION start")
-
-	store, ok := m.store.(*datastore.Datastore)
-	if !ok {
-		return nil // only migrate datastore
-	}
-
-	var project model.InternalProject
-	err := store.GetProject(projectID, &project)
-	if err != nil {
-		return errors.Wrap(err, "migration failed to get project")
-	}
-
-	// update to migrated version
-	project.Version = V0_12_0
-
 	// 1. reset project state
-	err = m.projects.Reset(&project)
+	createdAccounts, err := m.projects.Reset(&model.InternalProject{
+		ID: projectID,
+	})
 	if err != nil {
 		return errors.Wrap(err, "migration failed to reset project state")
 	}
@@ -152,44 +132,32 @@ func (m *Migrator) migrateToV0_12_0(projectID uuid.UUID) error {
 		return errors.Wrap(err, "migration failed to get accounts")
 	}
 
+	if len(accounts) != len(createdAccounts) {
+		return fmt.Errorf("migration failture, created accounts length doesn't match existing accounts")
+	}
+
 	// 2. migrate accounts
 	for i, acc := range accounts {
-		accounts[i].Address = adapter.AddressFromAPI(acc.Address)
-		accounts[i].DraftCode = adapter.ContentAddressFromAPI(acc.DraftCode)
+		acc.Address = createdAccounts[i].Address
+		acc.DraftCode = adapter.ContentAddressFromAPI(acc.DraftCode)
+
+		err = m.store.DeleteAccount(acc.ProjectChildID)
+		if err != nil {
+			return errors.Wrap(err, "migration failed to migrate accounts")
+		}
+
+		err = m.store.InsertAccount(acc)
+		if err != nil {
+			return errors.Wrap(err, "migration failed to migrate accounts")
+		}
 	}
 
-	var exes []*model.TransactionExecution
-	err = m.store.GetTransactionExecutionsForProject(projectID, &exes)
+	err = m.projects.UpdateVersion(projectID, V0_12_0)
 	if err != nil {
-		return errors.Wrap(err, "migration failed to get executions")
+		return errors.Wrap(err, "failed to update project version")
 	}
 
-	// 3. migrate transaction executions
-	for i, exe := range exes {
-		exes[i].Script = adapter.ContentAddressFromAPI(exe.Script)
-		for j, sig := range exe.Signers {
-			exes[i].Signers[j] = adapter.AddressFromAPI(sig)
-		}
-		for j, arg := range exe.Arguments {
-			exes[i].Arguments[j] = adapter.ContentAddressFromAPI(arg)
-		}
-	}
-
-	var scripts []*model.ScriptExecution
-	err = m.store.GetScriptExecutionsForProject(projectID, &scripts)
-	if err != nil {
-		return errors.Wrap(err, "migration failed to get scripts")
-	}
-
-	// 4. migrate scripts
-	for i, s := range scripts {
-		scripts[i].Script = adapter.ContentAddressFromAPI(s.Script)
-		for j, arg := range s.Arguments {
-			scripts[i].Arguments[j] = adapter.ContentAddressFromAPI(arg)
-		}
-	}
-
-	return store.MigrateToV0_12_0(project, accounts, exes, scripts)
+	return nil
 }
 
 func sanitizeVersion(version *semver.Version) *semver.Version {

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -117,7 +117,7 @@ func migrateTest(startVersion *semver.Version, f func(t *testing.T, c migrateTes
 		scripts := controller.NewScripts(store, chain)
 		projects := controller.NewProjects(startVersion, store, chain)
 
-		migrator := migrate.NewMigrator(projects)
+		migrator := migrate.NewMigrator(store, projects)
 
 		user := model.User{
 			ID: uuid.New(),

--- a/model/account.go
+++ b/model/account.go
@@ -42,6 +42,7 @@ func (a *InternalAccount) Load(ps []datastore.Property) error {
 		ProjectID string
 		Address   []byte
 		DraftCode string
+		Index     int
 	}{}
 
 	if err := datastore.LoadStruct(&tmp, ps); err != nil {
@@ -80,6 +81,10 @@ func (a *InternalAccount) Save() ([]datastore.Property, error) {
 		{
 			Name:  "DraftCode",
 			Value: a.DraftCode,
+		},
+		{
+			Name:  "Index",
+			Value: a.Index,
 		},
 	}, nil
 }

--- a/model/account.go
+++ b/model/account.go
@@ -38,11 +38,14 @@ func (a *InternalAccount) NameKey() *datastore.Key {
 
 func (a *InternalAccount) Load(ps []datastore.Property) error {
 	tmp := struct {
-		ID        string
-		ProjectID string
-		Address   []byte
-		DraftCode string
-		Index     int
+		ID                string
+		ProjectID         string
+		Address           []byte
+		DraftCode         string
+		Index             int
+		DeployedCode      any // leave it for backward compatibility
+		State             any // leave it for backward compatibility
+		DeployedContracts any // leave it for backward compatibility
 	}{}
 
 	if err := datastore.LoadStruct(&tmp, ps); err != nil {

--- a/model/account.go
+++ b/model/account.go
@@ -29,6 +29,7 @@ type InternalAccount struct {
 	ProjectChildID
 	Address   Address
 	DraftCode string
+	Index     int
 }
 
 func (a *InternalAccount) NameKey() *datastore.Key {

--- a/model/account.go
+++ b/model/account.go
@@ -58,7 +58,7 @@ func (a *InternalAccount) Load(ps []datastore.Property) error {
 	}
 
 	copy(a.Address[:], tmp.Address[:])
-
+	a.Index = tmp.Index
 	a.DraftCode = tmp.DraftCode
 
 	return nil

--- a/model/transaction.go
+++ b/model/transaction.go
@@ -244,6 +244,10 @@ func (t *TransactionExecution) Save() ([]datastore.Property, error) {
 			Name:  "Logs",
 			Value: logs,
 		},
+		{
+			Name:  "Index",
+			Value: t.Index,
+		},
 	}, nil
 }
 

--- a/playground_test.go
+++ b/playground_test.go
@@ -1109,7 +1109,7 @@ func TestTransactionExecutions(t *testing.T) {
 			eventA.Values[0],
 		)
 
-		err = projects.Reset(&model.InternalProject{
+		_, err = projects.Reset(&model.InternalProject{
 			ID: uuid.MustParse(project.ID),
 		})
 		require.NoError(t, err)
@@ -2639,7 +2639,4 @@ func createScriptTemplate(t *testing.T, c *Client, project Project) string {
 }
 
 // todo add tests for:
-// - checking account state
-// - deploying contract on account actually changes the returned account
 // - failed transactions with successful transactions work (bootstrap works)??
-// - add benchmark test for cached / uncached versions

--- a/playground_test.go
+++ b/playground_test.go
@@ -2547,7 +2547,6 @@ var version, _ = semver.NewVersion("0.1.0")
 func newClient() *Client {
 	var store storage.Store
 
-	// TODO: Should eventually start up the emulator and run all tests with datastore backend
 	if strings.EqualFold(os.Getenv("FLOW_STORAGEBACKEND"), "datastore") {
 		var err error
 		store, err = datastore.NewDatastore(context.Background(), &datastore.Config{

--- a/resolver.go
+++ b/resolver.go
@@ -309,6 +309,7 @@ func (r *queryResolver) Project(ctx context.Context, id uuid.UUID) (*model.Proje
 		return nil, errors.Wrap(err, "failed to get project")
 	}
 
+	// todo
 	// only migrate if current user has access to this project
 	migrated, err := r.migrator.MigrateProject(id, proj.Version, r.version)
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -151,7 +151,7 @@ func main() {
 	router.Use(monitoring.Middleware())
 
 	if conf.Debug {
-		logger := httplog.NewLogger("playground-api", httplog.Options{Concise: true})
+		logger := httplog.NewLogger("playground-api", httplog.Options{Concise: true, JSON: true})
 		router.Use(httplog.RequestLogger(logger))
 		router.Handle("/", gqlPlayground.Handler("GraphQL playground", "/query"))
 	}

--- a/storage/datastore/store.go
+++ b/storage/datastore/store.go
@@ -261,14 +261,12 @@ func (d *Datastore) ResetProjectState(proj *model.InternalProject) error {
 	}
 
 	var txExes []*model.TransactionExecution
-
 	err = d.GetTransactionExecutionsForProject(proj.ID, &txExes)
 	if err != nil {
 		return err
 	}
 
 	var scriptExes []*model.ScriptExecution
-
 	err = d.GetScriptExecutionsForProject(proj.ID, &scriptExes)
 	if err != nil {
 		return err

--- a/storage/datastore/store.go
+++ b/storage/datastore/store.go
@@ -278,7 +278,7 @@ func (d *Datastore) ResetProjectState(proj *model.InternalProject) error {
 		proj.TransactionCount = 0
 		proj.UpdatedAt = time.Now()
 
-		_, err = tx.Put(proj.NameKey(), &proj)
+		_, err = tx.Put(proj.NameKey(), proj)
 		if err != nil {
 			return err
 		}

--- a/storage/datastore/store.go
+++ b/storage/datastore/store.go
@@ -497,7 +497,6 @@ func (d *Datastore) InsertTransactionExecution(exe *model.TransactionExecution) 
 		}
 
 		exe.Index = proj.TransactionExecutionCount
-		// todo bug this is not saved to db for some reason
 
 		proj.TransactionExecutionCount++
 		proj.TransactionCount++

--- a/storage/datastore/store.go
+++ b/storage/datastore/store.go
@@ -276,6 +276,7 @@ func (d *Datastore) ResetProjectState(proj *model.InternalProject) error {
 
 	_, txErr := d.dsClient.RunInTransaction(ctx, func(tx *datastore.Transaction) error {
 		proj.TransactionCount = 0
+		proj.TransactionExecutionCount = 0
 		proj.UpdatedAt = time.Now()
 
 		_, err = tx.Put(proj.NameKey(), proj)
@@ -513,38 +514,6 @@ func (d *Datastore) InsertTransactionExecution(exe *model.TransactionExecution) 
 
 	return txErr
 
-}
-
-func (d *Datastore) MigrateToV0_12_0(
-	project model.InternalProject,
-	accounts []*model.InternalAccount,
-	exes []*model.TransactionExecution,
-	scripts []*model.ScriptExecution,
-) error {
-	ctx, cancel := context.WithTimeout(context.Background(), d.conf.DatastoreTimeout)
-	defer cancel()
-
-	var keys []*datastore.Key
-	var values []interface{}
-
-	keys = append(keys, project.NameKey())
-	values = append(values, project)
-
-	for _, exe := range exes {
-		keys = append(keys, exe.NameKey())
-		values = append(values, exe)
-	}
-	for _, acc := range accounts {
-		keys = append(keys, acc.NameKey())
-		values = append(values, acc)
-	}
-	for _, s := range scripts {
-		keys = append(keys, s.NameKey())
-		values = append(values, s)
-	}
-
-	_, err := d.dsClient.PutMulti(ctx, keys, values)
-	return err
 }
 
 func (d *Datastore) GetTransactionExecutionsForProject(projectID uuid.UUID, exes *[]*model.TransactionExecution) error {

--- a/storage/memory/store.go
+++ b/storage/memory/store.go
@@ -668,6 +668,7 @@ func (s *Store) ResetProjectState(proj *model.InternalProject) error {
 
 	project := s.projects[proj.ID]
 	project.TransactionCount = 0
+	project.TransactionExecutionCount = 0
 	s.projects[proj.ID] = project
 
 	*proj = project

--- a/storage/memory/store.go
+++ b/storage/memory/store.go
@@ -138,7 +138,6 @@ func (s *Store) UpdateProject(input model.UpdateProject, proj *model.InternalPro
 	}
 
 	s.projects[input.ID] = p
-
 	*proj = p
 
 	err := s.markProjectUpdatedAt(input.ID)
@@ -453,6 +452,11 @@ func (s *Store) InsertTransactionExecution(exe *model.TransactionExecution) erro
 	// set index to one after last
 	exe.Index = count
 	s.transactionExecutions[exe.ID] = *exe
+
+	proj := s.projects[exe.ProjectID]
+	proj.TransactionExecutionCount += 1
+	proj.TransactionCount += 1
+	s.projects[exe.ProjectID] = proj
 
 	err = s.markProjectUpdatedAt(exe.ProjectID)
 	if err != nil {

--- a/storage/memory/store.go
+++ b/storage/memory/store.go
@@ -288,7 +288,7 @@ func (s *Store) getAccountsForProject(projectID uuid.UUID, accs *[]*model.Intern
 
 	// sort results by index
 	sort.Slice(res, func(i, j int) bool {
-		return res[i].Address[len(res[i].Address)-1] < res[j].Address[len(res[j].Address)-1]
+		return res[i].Index < res[j].Index
 	})
 
 	*accs = res


### PR DESCRIPTION
This PR implements migration logic for the existing projects. It does so the first time a project is requested. Migration includes removing the transaction and script executions, removing all accounts, and recreating them. Tests were added to simulate old project in the database and assert it's successfully migrated to the new state.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

