### PR TITLE
State recreation bugfix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,12 @@ test:
 	GO111MODULE=on go test -v ./...
 
 .PHONY: test-datastore
-test-datastore:
+test-pg:
 	DATASTORE_EMULATOR_HOST=localhost:8081 FLOW_STORAGEBACKEND=datastore GO111MODULE=on go test -v ./...
 
 .PHONY: test-migration
 test-migration:
-	DATASTORE_EMULATOR_HOST=localhost:8081 FLOW_STORAGEBACKEND=datastore GO111MODULE=on go test ./migrate/... -run Test_MigrationV0_12_0
+	DATASTORE_EMULATOR_HOST=localhost:8081 FLOW_STORAGEBACKEND=datastore GO111MODULE=on go test ./migrate/...
 
 
 .PHONY: run
@@ -32,20 +32,18 @@ run:
 	-ldflags "-X github.com/dapperlabs/flow-playground-api/build.version=$(LAST_KNOWN_VERSION)" \
 	server/server.go
 
-.PHONY: run-datastore
-run-datastore:
-	DATASTORE_EMULATOR_HOST=localhost:8081 \
-	FLOW_STORAGEBACKEND=datastore \
-	FLOW_DATASTORE_GCPPROJECTID=flow-developer-playground \
+.PHONY: run-pg
+run-pg:
+	FLOW_DB_USER=postgres \
+	FLOW_DB_PORT=5432 \
+	FLOW_DB_NAME=dapper \
+	FLOW_DB_HOST=localhost \
+	FLOW_STORAGEBACKEND=postgresql \
 	FLOW_DEBUG=true FLOW_SESSIONCOOKIESSECURE=false \
 	GO111MODULE=on \
 	go run \
 	-ldflags "-X github.com/dapperlabs/flow-playground-api/build.version=$(LAST_KNOWN_VERSION)" \
 	server/server.go
-
-.PHONY: start-datastore-emulator
-start-datastore-emulator:
-	gcloud beta emulators datastore start --no-store-on-disk
 
 .PHONY: ci
 ci: check-tidy test check-headers

--- a/blockchain/cache.go
+++ b/blockchain/cache.go
@@ -36,6 +36,14 @@ func newEmulatorCache(capacity int) *emulatorCache {
 	}
 }
 
+// emulatorCache caches the emulator state.
+//
+// In the environment where multiple replicas maintain it's own cache copy it can get into multiple states:
+// - it can get stale because replica A receives transaction execution 1, and replica B receives transaction execution 2,
+//   then replica A needs to apply missed transaction execution 2 before continuing
+// - it can be outdated because replica A receives project reset, which clears all executions and the cache, but replica B
+//   doesn't receive that request so on next run it receives 0 executions but cached emulator contains state from previous
+//   executions that wasn't cleared
 type emulatorCache struct {
 	cache *lru.Cache
 }
@@ -46,10 +54,6 @@ func (c *emulatorCache) reset(ID uuid.UUID) {
 }
 
 // get returns a cached emulator if exists, but also checks if it's stale.
-//
-// based on the executions the function receives it compares that to the emulator block height, since
-// one execution is always one block it can compare the heights to the length. If it finds some executions
-// that are not part of emulator it returns that subset, so they can be applied on top.
 func (c *emulatorCache) get(ID uuid.UUID) *emulator {
 	val, ok := c.cache.Get(ID)
 	if !ok {

--- a/blockchain/cache_test.go
+++ b/blockchain/cache_test.go
@@ -54,13 +54,13 @@ func Test_Cache(t *testing.T) {
 		cacheEm := c.get(testID)
 		require.NotNil(t, cacheEm)
 
-		cacheBlock, err := cacheEm.getLatestBlock()
+		cacheHeight, err := cacheEm.getLatestBlockHeight()
 		require.NoError(t, err)
 
-		block, err := em.getLatestBlock()
+		height, err := em.getLatestBlockHeight()
 		require.NoError(t, err)
 
-		assert.Equal(t, block.ID(), cacheBlock.ID())
+		assert.Equal(t, height, cacheHeight)
 	})
 
 }

--- a/blockchain/emulator.go
+++ b/blockchain/emulator.go
@@ -20,8 +20,6 @@ package blockchain
 
 import (
 	"fmt"
-	"github.com/onflow/flow-go/model/flow"
-
 	"github.com/getsentry/sentry-go"
 	"github.com/onflow/cadence"
 	jsoncdc "github.com/onflow/cadence/encoding/json"
@@ -61,8 +59,8 @@ type blockchain interface {
 	// deployContract deploys a contract on the provided address and returns transaction and result.
 	deployContract(address flowsdk.Address, script string) (*types.TransactionResult, *flowsdk.Transaction, error)
 
-	// getLatestBlock from the network.
-	getLatestBlock() (*flow.Block, error)
+	// getLatestBlock height from the network.
+	getLatestBlockHeight() (int, error)
 }
 
 var _ blockchain = &emulator{}
@@ -221,8 +219,12 @@ func (e *emulator) sendTransaction(
 	return res[0], tx, nil
 }
 
-func (e *emulator) getLatestBlock() (*flow.Block, error) {
-	return e.blockchain.GetLatestBlock()
+func (e *emulator) getLatestBlockHeight() (int, error) {
+	block, err := e.blockchain.GetLatestBlock()
+	if err != nil {
+		return 0, err
+	}
+	return int(block.Header.Height), nil
 }
 
 // parseEventAddress gets an address out of the account creation events payloads

--- a/blockchain/projects.go
+++ b/blockchain/projects.go
@@ -276,13 +276,13 @@ func (p *Projects) load(projectID uuid.UUID) (blockchain, error) {
 		return nil, err
 	}
 
-	//em := p.emulatorCache.get(projectID)
-	//if em == nil {
-	em, err := newEmulator()
-	if err != nil {
-		return nil, err
+	em := p.emulatorCache.get(projectID)
+	if em == nil {
+		em, err = newEmulator()
+		if err != nil {
+			return nil, err
+		}
 	}
-	//}
 
 	executions, err = p.filterMissingExecutions(em, executions)
 	if err != nil {
@@ -294,7 +294,7 @@ func (p *Projects) load(projectID uuid.UUID) (blockchain, error) {
 		return nil, err
 	}
 
-	//p.emulatorCache.add(projectID, em)
+	p.emulatorCache.add(projectID, em)
 
 	return em, nil
 }

--- a/blockchain/projects.go
+++ b/blockchain/projects.go
@@ -276,13 +276,13 @@ func (p *Projects) load(projectID uuid.UUID) (blockchain, error) {
 		return nil, err
 	}
 
-	em := p.emulatorCache.get(projectID)
-	if em == nil {
-		em, err = newEmulator()
-		if err != nil {
-			return nil, err
-		}
+	//em := p.emulatorCache.get(projectID)
+	//if em == nil {
+	em, err := newEmulator()
+	if err != nil {
+		return nil, err
 	}
+	//}
 
 	executions, err = p.filterMissingExecutions(em, executions)
 	if err != nil {
@@ -293,6 +293,8 @@ func (p *Projects) load(projectID uuid.UUID) (blockchain, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	//p.emulatorCache.add(projectID, em)
 
 	return em, nil
 }
@@ -323,10 +325,7 @@ func (p *Projects) runMissingExecutions(
 				result.Error.Error(),
 				result.Debug,
 			)
-			event := sentry.NewEvent()
-			event.Level = sentry.LevelError
-			event.Message = "State recreation failure"
-			event.Contexts = map[string]interface{}{
+			fmt.Println(map[string]interface{}{
 				"Logs":       result.Logs,
 				"Events":     result.Events,
 				"Debug":      result.Debug,
@@ -335,8 +334,9 @@ func (p *Projects) runMissingExecutions(
 				"ExeArgs":    execution.Arguments,
 				"ExeLogs":    execution.Logs,
 				"ExeSigners": execution.Signers,
-			}
-			sentry.CaptureEvent(event)
+			})
+
+			sentry.CaptureException(err)
 			return nil, err
 		}
 	}

--- a/blockchain/projects.go
+++ b/blockchain/projects.go
@@ -297,6 +297,7 @@ func (p *Projects) load(projectID uuid.UUID) (blockchain, error) {
 		if err != nil {
 			return nil, err
 		}
+		height = 0
 	}
 
 	executions, err = p.filterMissingExecutions(executions, height)

--- a/blockchain/projects.go
+++ b/blockchain/projects.go
@@ -353,6 +353,11 @@ func (p *Projects) runMissingExecutions(
 	return em, nil
 }
 
+// filterMissingExecutions gets all missed executions in current replica cache
+//
+// based on the executions the function receives it compares that to the emulator block height, since
+// one execution is always one block it can compare the heights to the length. If it finds some executions
+// that are not part of emulator it returns that subset, so they can be applied on top.
 func (p *Projects) filterMissingExecutions(
 	executions []*model.TransactionExecution,
 	height int,

--- a/blockchain/projects_test.go
+++ b/blockchain/projects_test.go
@@ -114,8 +114,6 @@ func Benchmark_LoadEmulator(b *testing.B) {
 }
 
 func Test_ConcurrentRequests(t *testing.T) {
-	//t.Skip("") // todo remove
-
 	testConcurrently := func(
 		numOfRequests int,
 		request func(i int, ch chan any, wg *sync.WaitGroup, projects *Projects, proj *model.Project),

--- a/blockchain/projects_test.go
+++ b/blockchain/projects_test.go
@@ -207,10 +207,10 @@ func Test_LoadEmulator(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		block, err := emulator.getLatestBlock()
+		height, err := emulator.getLatestBlockHeight()
 		require.NoError(t, err)
 
-		require.Equal(t, uint64(0), block.Header.Height)
+		require.Equal(t, 0, height)
 	})
 
 	t.Run("multiple loads with low cache", func(t *testing.T) {
@@ -258,10 +258,35 @@ func Test_LoadEmulator(t *testing.T) {
 		emulator, err := projects.load(proj.ID)
 		require.NoError(t, err)
 
-		latest, err := emulator.getLatestBlock()
+		latest, err := emulator.getLatestBlockHeight()
 		require.NoError(t, err)
 		// there should be two blocks created, one from first execution and second from direct db execution from above
-		assert.Equal(t, uint64(2), latest.Header.Height)
+		assert.Equal(t, 2, latest)
+	})
+
+	// this tests that if another replica receives project reset, then this replica won't clear the cache,
+	// so it needs to force-reset if it gets 0 executions from db even if emulator is on higher height
+	t.Run("reset project on another replica", func(t *testing.T) {
+		projects, store, proj, err := newWithSeededProject()
+		require.NoError(t, err)
+
+		_, err = projects.ExecuteTransaction(model.NewTransactionExecution{
+			ProjectID: proj.ID,
+			Script:    `transaction {}`,
+			Signers:   nil,
+			Arguments: nil,
+		})
+		require.NoError(t, err)
+
+		err = store.ResetProjectState(proj)
+		require.NoError(t, err)
+
+		emulator, err := projects.load(proj.ID)
+		require.NoError(t, err)
+
+		latest, err := emulator.getLatestBlockHeight()
+		require.NoError(t, err)
+		assert.Equal(t, 0, latest) // no exe since reset
 	})
 }
 
@@ -378,8 +403,8 @@ func Test_TransactionExecution(t *testing.T) {
 		}
 
 		em, _ := projects.load(proj.ID)
-		b, _ := em.getLatestBlock()
-		assert.Equal(t, uint64(0), b.Header.Height)
+		b, _ := em.getLatestBlockHeight()
+		assert.Equal(t, 0, b)
 
 		executeAndAssert := func(exeLen int) {
 			exe, err := projects.ExecuteTransaction(tx)
@@ -393,8 +418,8 @@ func Test_TransactionExecution(t *testing.T) {
 			require.Len(t, dbExe, exeLen)
 
 			em, _ := projects.load(proj.ID)
-			b, _ := em.getLatestBlock()
-			require.Equal(t, uint64(exeLen), b.Header.Height)
+			b, _ := em.getLatestBlockHeight()
+			require.Equal(t, exeLen, b)
 
 			projects.emulatorCache.reset(proj.ID)
 		}

--- a/controller/projects.go
+++ b/controller/projects.go
@@ -36,7 +36,7 @@ type Projects struct {
 }
 
 func NewProjects(
-	version *semver.Version,
+	version *semver.Version, // todo remove this
 	store storage.Store,
 	blockchain *blockchain.Projects,
 ) *Projects {

--- a/controller/projects.go
+++ b/controller/projects.go
@@ -36,7 +36,7 @@ type Projects struct {
 }
 
 func NewProjects(
-	version *semver.Version, // todo remove this
+	version *semver.Version,
 	store storage.Store,
 	blockchain *blockchain.Projects,
 ) *Projects {

--- a/controller/projects_test.go
+++ b/controller/projects_test.go
@@ -19,7 +19,9 @@
 package controller
 
 import (
+	"fmt"
 	"github.com/kelseyhightower/envconfig"
+	"github.com/onflow/flow-go-sdk"
 	"github.com/stretchr/testify/assert"
 	"os"
 	"strings"
@@ -32,7 +34,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func createProjects(t *testing.T) (*Projects, storage.Store, *model.User) {
+func createStore() storage.Store {
 	var store storage.Store
 
 	if strings.EqualFold(os.Getenv("FLOW_STORAGEBACKEND"), storage.PostgreSQL) {
@@ -46,15 +48,38 @@ func createProjects(t *testing.T) (*Projects, storage.Store, *model.User) {
 		store = storage.NewInMemory()
 	}
 
+	return store
+}
+
+func createUser(store storage.Store) *model.User {
 	user := &model.User{
 		ID: uuid.New(),
 	}
 
 	err := store.InsertUser(user)
-	require.NoError(t, err)
+	if err != nil {
+		panic(err)
+	}
+	return user
+}
 
+func createProjects(t *testing.T) (*Projects, storage.Store, *model.User) {
+	store := createStore()
+	user := createUser(store)
 	chain := blockchain.NewProjects(store, 5)
 	return NewProjects(version, store, chain), store, user
+}
+
+func createControllers() (storage.Store, *model.User, *blockchain.Projects, *Projects, *Transactions, *Scripts, *Accounts) {
+	store := createStore()
+	user := createUser(store)
+	chain := blockchain.NewProjects(store, 5)
+	projects := NewProjects(version, store, chain)
+	txs := NewTransactions(store, chain)
+	scripts := NewScripts(store, chain)
+	accs := NewAccounts(store, chain)
+
+	return store, user, chain, projects, txs, scripts, accs
 }
 
 func seedProject(projects *Projects, user *model.User) *model.Project {
@@ -155,4 +180,114 @@ func Test_CreateProject(t *testing.T) {
 
 		assert.Equal(t, 5, dbProj.TransactionExecutionCount)
 	})
+}
+
+func Test_StateRecreation(t *testing.T) {
+	_, user, _, projects, transactions, _, accounts := createControllers()
+
+	contract1 := `pub contract HelloWorld { 
+		init() {
+			log("hello")
+		} 
+	}`
+
+	tx1 := `transaction {
+		prepare(auth: AuthAccount) {}
+		execute {
+			log("hello tx")		
+		}
+	}`
+
+	script1 := `pub fun main(): Int {
+		return 42;
+	}`
+
+	txTpls := []*model.NewProjectTransactionTemplate{{
+		Title:  "tx template 1",
+		Script: tx1,
+	}}
+
+	scTpls := []*model.NewProjectScriptTemplate{{
+		Title:  "script template 1",
+		Script: script1,
+	}}
+
+	newProject := model.NewProject{
+		ParentID:             nil,
+		Title:                "Test Title",
+		Description:          "Test Desc",
+		Readme:               "Test Readme",
+		Seed:                 1,
+		Accounts:             []string{contract1, contract1, contract1},
+		TransactionTemplates: txTpls,
+		ScriptTemplates:      scTpls,
+	}
+
+	p, err := projects.Create(user, newProject)
+	require.NoError(t, err)
+
+	newProj, err := projects.Get(p.ID)
+	require.NoError(t, err)
+
+	newAccs, err := accounts.AllForProjectID(newProj.ID)
+	require.NoError(t, err)
+
+	for _, a := range newAccs {
+		assert.Equal(t, "", a.DeployedCode)
+	}
+
+	for i := 0; i < 2; i++ {
+		deployAcc, err := accounts.Update(model.UpdateAccount{
+			ID:           newAccs[i].ID,
+			ProjectID:    newProj.ID,
+			DeployedCode: &contract1,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, contract1, deployAcc.DeployedCode)
+	}
+
+	redeployAcc, err := accounts.Update(model.UpdateAccount{
+		ID:           newAccs[0].ID,
+		ProjectID:    newProj.ID,
+		DeployedCode: &contract1,
+	})
+
+	// check what deployed on accounts
+	allAccs, err := accounts.AllForProjectID(newProj.ID)
+	require.NoError(t, err)
+	for i, rAcc := range allAccs {
+		assert.Equal(t, // asserting that account addresses are ordered
+			flow.HexToAddress(fmt.Sprintf("0x0%d", i+5)).String(),
+			rAcc.Address.ToFlowAddress().String(),
+		)
+		if rAcc.ID == redeployAcc.ID {
+			// only one redeploy account has deployed code due to clear state
+			assert.Equal(t, contract1, rAcc.DeployedCode)
+		} else {
+			assert.Equal(t, "", rAcc.DeployedCode)
+		}
+	}
+
+	tx2 := `import HelloWorld from 0x05
+		transaction {
+			prepare(auth: AuthAccount) {}
+			execute {}
+		}`
+
+	for i := 0; i < 5; i++ {
+		txExe, err := transactions.CreateTransactionExecution(model.NewTransactionExecution{
+			ProjectID: newProj.ID,
+			Script:    tx2,
+			Signers:   []model.Address{redeployAcc.Address},
+		})
+		require.NoError(t, err)
+		assert.Len(t, txExe.Errors, 0)
+	}
+
+	exes, err := transactions.AllExecutionsForProjectID(newProj.ID)
+	for i, exe := range exes {
+		assert.Equal(t, exe.Index, i)
+	}
+
 }

--- a/server/server.go
+++ b/server/server.go
@@ -79,8 +79,13 @@ func main() {
 		log.Fatal(err)
 	}
 
+	semVer := ""
+	if build.Version() != nil {
+		semVer = build.Version().String()
+	}
+
 	err := sentry.Init(sentry.ClientOptions{
-		Release:          build.Version().String(),
+		Release:          semVer,
 		Dsn:              sentryConf.Dsn,
 		Debug:            sentryConf.Debug,
 		AttachStacktrace: sentryConf.AttachStacktrace,

--- a/storage/sql.go
+++ b/storage/sql.go
@@ -37,11 +37,11 @@ const PostgreSQL = "postgresql"
 
 // NewInMemory database, warning not concurrency safe, do not use for e2e tests
 func NewInMemory() *SQL {
-	return newSQL(sqlite.Open(":memory:"), logger.Info)
+	return newSQL(sqlite.Open(":memory:"), logger.Warn)
 }
 
 func NewSqlite() *SQL {
-	return newSQL(sqlite.Open("./e2e-db"), logger.Info)
+	return newSQL(sqlite.Open("./e2e-db"), logger.Warn)
 }
 
 type DatabaseConfig struct {

--- a/storage/sql.go
+++ b/storage/sql.go
@@ -37,11 +37,11 @@ const PostgreSQL = "postgresql"
 
 // NewInMemory database, warning not concurrency safe, do not use for e2e tests
 func NewInMemory() *SQL {
-	return newSQL(sqlite.Open(":memory:"), logger.Warn)
+	return newSQL(sqlite.Open(":memory:"), logger.Info)
 }
 
 func NewSqlite() *SQL {
-	return newSQL(sqlite.Open("./e2e-db"), logger.Warn)
+	return newSQL(sqlite.Open("./e2e-db"), logger.Info)
 }
 
 type DatabaseConfig struct {
@@ -227,8 +227,8 @@ func (s *SQL) GetAccount(id, pID uuid.UUID, acc *model.Account) error {
 func (s *SQL) GetAccountsForProject(pID uuid.UUID, accs *[]*model.Account) error {
 	return s.db.
 		Where(&model.Account{ProjectID: pID}).
+		Order("\"index\" asc").
 		Find(accs).
-		Order("index asc").
 		Error
 }
 
@@ -326,8 +326,8 @@ func (s *SQL) InsertTransactionExecution(exe *model.TransactionExecution) error 
 
 func (s *SQL) GetTransactionExecutionsForProject(pID uuid.UUID, exes *[]*model.TransactionExecution) error {
 	return s.db.Where(&model.TransactionExecution{ProjectID: pID}).
+		Order("\"index\" asc").
 		Find(exes).
-		Order("index asc").
 		Error
 }
 


### PR DESCRIPTION
Closes: #67 
Closes: #68 
Closes: #75 

Fixing state invalidation in the case where there was a project reset on replica A but cached emulator was used on replica B that should in turn be reset.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

