### PR TITLE
Remove turbolent as code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @psiemens @turbolent @janezpodhostnik @sideninja @DylanTinianov
+* @psiemens @janezpodhostnik @sideninja @DylanTinianov


### PR DESCRIPTION
## Description

Now that we have more code owners and contributors, I don't think it makes much sense for me to be a code owner.

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

