### PR TITLE
Create stale project scanner

### DIFF
--- a/controller/projects.go
+++ b/controller/projects.go
@@ -34,6 +34,9 @@ import (
 // MaxProjectsLimit limit on the number of projects a user can create
 const MaxProjectsLimit = 10
 
+// StaleDuration is the amount a time before a project is considered stale if not accessed
+const StaleDuration = (time.Hour * 24) * 90 // 90 days
+
 type Projects struct {
 	version    *semver.Version
 	store      storage.Store
@@ -194,13 +197,17 @@ func (p *Projects) UpdateVersion(id uuid.UUID, version *semver.Version) error {
 }
 
 func (p *Projects) GetStaleProjects() ([]*model.Project, error) {
-	var stale []*model.Project
-	err := p.store.GetStaleProjects(&stale)
+	var projs []*model.Project
+	err := p.store.GetStaleProjects(StaleDuration, &projs)
 	if err != nil {
 		return nil, err
 	}
 
-	return stale, nil
+	return projs, nil
+}
+
+func (p *Projects) DeleteStaleProjects() error {
+	return p.store.DeleteStaleProjects(StaleDuration)
 }
 
 // Reset is not used in the API but for testing

--- a/controller/projects_test.go
+++ b/controller/projects_test.go
@@ -19,7 +19,6 @@
 package controller
 
 import (
-	"fmt"
 	"github.com/dapperlabs/flow-playground-api/server/config"
 	"github.com/kelseyhightower/envconfig"
 	"github.com/onflow/flow-go-sdk"
@@ -203,11 +202,108 @@ func Test_AccessedTime(t *testing.T) {
 		require.NoError(t, err)
 
 		require.True(t, project.AccessedAt.Before(getProj.AccessedAt))
+	})
+}
 
-		stale, err := projects.GetStaleProjects()
+func Test_StaleProjects(t *testing.T) {
+	projects, store, user := createProjects()
+
+	t.Run("get stale projects", func(t *testing.T) {
+		for i := 0; i < 5; i++ {
+			project, err := seedProject(projects, user)
+			require.NoError(t, err)
+			require.NotEmpty(t, project.AccessedAt)
+		}
+
+		stale := time.Second * 1
+
+		// Make all projects stale
+		time.Sleep(time.Second * 2)
+
+		var staleProjects []*model.Project
+		err := store.GetStaleProjects(stale, &staleProjects)
+		require.NoError(t, err)
+		require.Equal(t, 5, len(staleProjects))
+	})
+
+	t.Run("no stale projects", func(t *testing.T) {
+		for i := 0; i < 5; i++ {
+			project, err := seedProject(projects, user)
+			require.NoError(t, err)
+			require.NotEmpty(t, project.AccessedAt)
+		}
+
+		stale := time.Hour * 1
+
+		time.Sleep(time.Second * 2)
+
+		var staleProjects []*model.Project
+		err := store.GetStaleProjects(stale, &staleProjects)
+		require.NoError(t, err)
+		require.Empty(t, staleProjects)
+	})
+
+	t.Run("delete stale projects", func(t *testing.T) {
+		for i := 0; i < 5; i++ {
+			project, err := seedProject(projects, user)
+			require.NoError(t, err)
+			require.NotEmpty(t, project.AccessedAt)
+
+			err = store.InsertScriptExecution(&model.ScriptExecution{
+				File: model.File{
+					ID:        uuid.New(),
+					ProjectID: project.ID,
+					Title:     "title",
+					Type:      0,
+					Index:     0,
+					Script:    "script",
+				},
+			})
+			require.NoError(t, err)
+		}
+
+		// This execution should not be deleted
+		newProjID := uuid.New()
+		err := store.InsertScriptExecution(&model.ScriptExecution{
+			File: model.File{
+				ID:        uuid.New(),
+				ProjectID: newProjID,
+				Title:     "title",
+				Type:      0,
+				Index:     0,
+				Script:    "script",
+			},
+		})
 		require.NoError(t, err)
 
-		fmt.Println("STALE: ", len(stale))
+		stale := time.Second * 1
+
+		// Make all projects stale
+		time.Sleep(time.Second * 2)
+
+		var staleProjects []*model.Project
+		err = store.GetStaleProjects(stale, &staleProjects)
+		require.NoError(t, err)
+		require.NotEmpty(t, staleProjects)
+
+		var exes []*model.ScriptExecution
+		err = store.GetScriptExecutionsForProject(staleProjects[0].ID, &exes)
+		require.NotEmpty(t, exes)
+
+		testProjID := staleProjects[0].ID
+
+		err = store.DeleteStaleProjects(stale)
+		require.NoError(t, err)
+
+		err = store.GetStaleProjects(stale, &staleProjects)
+		require.NoError(t, err)
+		require.Empty(t, staleProjects)
+
+		err = store.GetScriptExecutionsForProject(testProjID, &exes)
+		require.Empty(t, exes)
+
+		err = store.GetScriptExecutionsForProject(newProjID, &exes)
+		require.NotEmpty(t, exes)
 	})
 }
 

--- a/controller/projects_test.go
+++ b/controller/projects_test.go
@@ -183,9 +183,9 @@ func Test_CreateProject(t *testing.T) {
 }
 
 func Test_AccessedTime(t *testing.T) {
-	projects, store, user := createProjects()
-
 	t.Run("update accessed time", func(t *testing.T) {
+		projects, store, user := createProjects()
+
 		project, err := seedProject(projects, user)
 		require.NoError(t, err)
 		require.NotEmpty(t, project.AccessedAt)
@@ -206,9 +206,9 @@ func Test_AccessedTime(t *testing.T) {
 }
 
 func Test_StaleProjects(t *testing.T) {
-	projects, store, user := createProjects()
-
 	t.Run("get stale projects", func(t *testing.T) {
+		projects, store, user := createProjects()
+
 		for i := 0; i < 5; i++ {
 			project, err := seedProject(projects, user)
 			require.NoError(t, err)
@@ -227,6 +227,8 @@ func Test_StaleProjects(t *testing.T) {
 	})
 
 	t.Run("no stale projects", func(t *testing.T) {
+		projects, store, user := createProjects()
+
 		for i := 0; i < 5; i++ {
 			project, err := seedProject(projects, user)
 			require.NoError(t, err)
@@ -244,6 +246,8 @@ func Test_StaleProjects(t *testing.T) {
 	})
 
 	t.Run("delete stale projects", func(t *testing.T) {
+		projects, store, user := createProjects()
+
 		for i := 0; i < 5; i++ {
 			project, err := seedProject(projects, user)
 			require.NoError(t, err)

--- a/controller/projects_test.go
+++ b/controller/projects_test.go
@@ -288,6 +288,7 @@ func Test_StaleProjects(t *testing.T) {
 
 		var exes []*model.ScriptExecution
 		err = store.GetScriptExecutionsForProject(staleProjects[0].ID, &exes)
+		require.NoError(t, err)
 		require.NotEmpty(t, exes)
 
 		testProjID := staleProjects[0].ID
@@ -300,9 +301,11 @@ func Test_StaleProjects(t *testing.T) {
 		require.Empty(t, staleProjects)
 
 		err = store.GetScriptExecutionsForProject(testProjID, &exes)
+		require.NoError(t, err)
 		require.Empty(t, exes)
 
 		err = store.GetScriptExecutionsForProject(newProjID, &exes)
+		require.NoError(t, err)
 		require.NotEmpty(t, exes)
 	})
 }

--- a/e2eTest/project_test.go
+++ b/e2eTest/project_test.go
@@ -335,7 +335,7 @@ func TestProjectUpdatedTime(t *testing.T) {
 		cookie := c.SessionCookie()
 		projectID := projResp1.CreateProject.ID
 
-		time.Sleep(time.Second * 1)
+		time.Sleep(time.Second * 2)
 
 		var projResp2 UpdateProjectResponse
 		err = c.Post(
@@ -379,6 +379,8 @@ func TestProjectUpdatedTime(t *testing.T) {
 
 		cookie := c.SessionCookie()
 		projectID := projResp1.CreateProject.ID
+
+		time.Sleep(time.Second * 2)
 
 		var templateResp CreateContractTemplateResponse
 		err = c.Post(

--- a/model/project.go
+++ b/model/project.go
@@ -41,6 +41,7 @@ type Project struct {
 	Persist                   bool
 	CreatedAt                 time.Time
 	UpdatedAt                 time.Time
+	AccessedAt                time.Time
 	Version                   *semver.Version `gorm:"serializer:json"`
 	Mutable                   bool            // todo don't persist this
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -20,10 +20,10 @@ package storage
 
 import (
 	"errors"
-
 	"github.com/Masterminds/semver"
 	"github.com/dapperlabs/flow-playground-api/model"
 	"github.com/google/uuid"
+	"time"
 )
 
 type Store interface {
@@ -42,8 +42,10 @@ type Store interface {
 	ProjectAccessed(id uuid.UUID) error
 	GetAllProjectsForUser(userID uuid.UUID, proj *[]*model.Project) error
 	GetProjectCountForUser(userID uuid.UUID, count *int64) error
-	GetStaleProjects(stale *[]*model.Project) error
 	DeleteProject(id uuid.UUID) error
+
+	GetStaleProjects(stale time.Duration, projs *[]*model.Project) error
+	DeleteStaleProjects(stale time.Duration) error
 
 	InsertFile(file *model.File) error
 	UpdateFile(input model.UpdateFile, file *model.File) error

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -39,8 +39,10 @@ type Store interface {
 	UpdateProjectVersion(id uuid.UUID, version *semver.Version) error
 	ResetProjectState(proj *model.Project) error
 	GetProject(id uuid.UUID, proj *model.Project) error
+	ProjectAccessed(id uuid.UUID) error
 	GetAllProjectsForUser(userID uuid.UUID, proj *[]*model.Project) error
 	GetProjectCountForUser(userID uuid.UUID, count *int64) error
+	GetStaleProjects(stale *[]*model.Project) error
 	DeleteProject(id uuid.UUID) error
 
 	InsertFile(file *model.File) error


### PR DESCRIPTION
Closes: #139 

## Description
Added functionality for finding and deleting stale projects:
- Added AccessedAt field to the project model in order to determine the last time a project was accessed
- Added storage functions for finding and deleting stale projects
- Added testing to ensure stale projects can be found and correctly deleted along with corresponding file, executions, and deployments

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

