### PR TITLE
Create authorization error type

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -20,6 +20,7 @@ package auth
 
 import (
 	"context"
+	errorTypes "github.com/dapperlabs/flow-playground-api/middleware/errors"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 
@@ -71,7 +72,7 @@ func (a *Authenticator) GetOrCreateUser(ctx context.Context) (*model.User, error
 	} else {
 		user, err = a.getCurrentUser(session.Values[userIDKey].(string))
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to load user from session")
+			return nil, errorTypes.NewAuthorizationError("failed to load user from session")
 		}
 	}
 

--- a/middleware/errors/types.go
+++ b/middleware/errors/types.go
@@ -1,0 +1,51 @@
+/*
+ * Flow Playground
+ *
+ * Copyright 2019 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package errors
+
+import (
+	"errors"
+	"fmt"
+)
+
+var ServerErr = errors.New("something went wrong, we are looking into the issue")
+var GraphqlErr = errors.New("invalid graphql request")
+
+type AuthorizationError struct {
+	msg string
+}
+
+func NewAuthorizationError(msg string) *AuthorizationError {
+	return &AuthorizationError{msg}
+}
+
+func (i *AuthorizationError) Error() string {
+	return fmt.Sprintf("authorization error: %s", i.msg)
+}
+
+type UserError struct {
+	msg string
+}
+
+func NewUserError(msg string) *UserError {
+	return &UserError{msg}
+}
+
+func (i *UserError) Error() string {
+	return fmt.Sprintf("user error: %s", i.msg)
+}

--- a/middleware/errors/types.go
+++ b/middleware/errors/types.go
@@ -24,8 +24,8 @@ import (
 )
 
 var (
-	ServerErr        = errors.New("something went wrong, we are looking into the issue")
-	GraphqlErr       = errors.New("invalid graphql request")
+	ServerErr  error = errors.New("something went wrong, we are looking into the issue")
+	GraphqlErr error = errors.New("invalid graphql request")
 	_          error = &AuthorizationError{}
 	_          error = &UserError{}
 )

--- a/middleware/errors/types.go
+++ b/middleware/errors/types.go
@@ -23,8 +23,12 @@ import (
 	"fmt"
 )
 
-var ServerErr = errors.New("something went wrong, we are looking into the issue")
-var GraphqlErr = errors.New("invalid graphql request")
+var (
+	ServerErr        = errors.New("something went wrong, we are looking into the issue")
+	GraphqlErr       = errors.New("invalid graphql request")
+	_          error = &AuthorizationError{}
+	_          error = &UserError{}
+)
 
 type AuthorizationError struct {
 	msg string


### PR DESCRIPTION
Closes: #153 

## Description
Added a new AuthorizationError type. This will prevent session errors from falsely increasing our error rate metrics.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

