### PR TITLE
Fix double-translated addresses

### DIFF
--- a/adapter/address.go
+++ b/adapter/address.go
@@ -51,12 +51,9 @@ func contentAddressToAPI(input string) string {
 
 func contentAdapter(input string, fromInput bool) string {
 	if fromInput {
-		input = r.ReplaceAllStringFunc(input, translateFrom)
-	} else {
-		input = r.ReplaceAllStringFunc(input, translateTo)
+		return r.ReplaceAllStringFunc(input, translateFrom)
 	}
-
-	return input
+	return r.ReplaceAllStringFunc(input, translateTo)
 }
 
 func translateFrom(input string) string {

--- a/adapter/address_test.go
+++ b/adapter/address_test.go
@@ -65,6 +65,34 @@ func Test_ContentAdapter(t *testing.T) {
 		in:        "0x01",
 		out:       "0x01",
 		fromInput: false,
+	}, {
+		in: `
+			import Foo from 0x01
+			import Zoo from 0x05
+			pub fun main(): Address { return 0x01 }
+			pub fun main(): Address { return 0x05 }
+		`,
+		out: `
+			import Foo from 0x05
+			import Zoo from 0x09
+			pub fun main(): Address { return 0x05 }
+			pub fun main(): Address { return 0x09 }
+		`,
+		fromInput: true,
+	}, {
+		in: `
+			import Foo from 0x05
+			import Zoo from 0x09
+			pub fun main(): Address { return 0x05 }
+			pub fun main(): Address { return 0x09 }
+		`,
+		out: `
+			import Foo from 0x01
+			import Zoo from 0x05
+			pub fun main(): Address { return 0x01 }
+			pub fun main(): Address { return 0x05 }
+		`,
+		fromInput: false,
 	}}
 
 	for _, vector := range testVectors {

--- a/adapter/models.go
+++ b/adapter/models.go
@@ -40,7 +40,7 @@ func TransactionToAPI(tx *model.TransactionExecution) *model.TransactionExecutio
 	tx.Signers = addressesToAPI(tx.Signers)
 
 	for i, arg := range tx.Arguments {
-		tx.Arguments[i] = ContentAddressFromAPI(arg)
+		tx.Arguments[i] = contentAddressToAPI(arg)
 	}
 
 	for i, e := range tx.Events {

--- a/playground_test.go
+++ b/playground_test.go
@@ -2392,7 +2392,7 @@ func TestScriptExecutions(t *testing.T) {
 
 		const script = `
 			import contractA from 0x01
-			import FungibleToken from 0x05
+			import contractB from 0x05
 			pub fun main(): Address { return 0x01 }`
 
 		err := c.Post(
@@ -2404,12 +2404,11 @@ func TestScriptExecutions(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		// Ensure the declaration address is 0000000000000005 and not 0000000000000009
-		require.Contains(t, resp.CreateScriptExecution.Errors,
-			"{cannot find declaration `contractA` in `0000000000000005.contractA` 0x14006d25428 0x14006d25440}")
+		require.Equal(t, "cannot find declaration `contractA` in `0000000000000005.contractA`",
+			resp.CreateScriptExecution.Errors[0].Message)
 
-		require.Contains(t, resp.CreateScriptExecution.Errors,
-			"{cannot find declaration `FungibleToken` in `0000000000000005.FungibleToken` 0x14006d25428 0x14006d25440}")
+		require.Equal(t, "cannot find declaration `contractB` in `0000000000000009.contractB`",
+			resp.CreateScriptExecution.Errors[1].Message)
 	})
 
 	t.Run("invalid (parse error)", func(t *testing.T) {


### PR DESCRIPTION
Closes: #125 

## Description
Fixed the issue where addresses were sometimes being double translated.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

