### PR TITLE
Add contract title to deployments

### DIFF
--- a/e2eTest/constants.go
+++ b/e2eTest/constants.go
@@ -446,6 +446,7 @@ mutation($projectId: UUID!, $script: String!, $address: Address!) {
 	address: $address
   }) {
     id
+	title
     script
     address
     errors {
@@ -497,6 +498,7 @@ mutation($projectId: UUID!, $title: String!, $script: String!) {
 type CreateContractDeploymentResponse struct {
 	CreateContractDeployment struct {
 		ID      string
+		Title   string
 		Script  string
 		Address string
 		Errors  []model.ProgramError

--- a/e2eTest/contract_deployments_test.go
+++ b/e2eTest/contract_deployments_test.go
@@ -53,6 +53,29 @@ func TestContractDeployments(t *testing.T) {
 
 }
 
+func TestContractTitleParsing(t *testing.T) {
+	c := newClient()
+
+	project := createProject(t, c)
+	contractA := `
+		pub contract HelloWorld {
+			pub var A: Int
+			pub init() { self.A = 5 }
+		}`
+
+	var respA CreateContractDeploymentResponse
+	err := c.Post(
+		MutationCreateContractDeployment,
+		&respA,
+		client.Var("projectId", project.ID),
+		client.Var("script", contractA),
+		client.Var("address", addr1),
+		client.AddCookie(c.SessionCookie()),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "HelloWorld", respA.CreateContractDeployment.Title)
+}
+
 func TestContractRedeployment(t *testing.T) {
 	t.Run("same contract name with different arguments", func(t *testing.T) {
 		c := newClient()

--- a/e2eTest/contract_deployments_test.go
+++ b/e2eTest/contract_deployments_test.go
@@ -59,8 +59,7 @@ func TestContractTitleParsing(t *testing.T) {
 	project := createProject(t, c)
 	contractA := `
 		pub contract HelloWorld {
-			pub var A: Int
-			pub init() { self.A = 5 }
+			pub init() {}
 		}`
 
 	var respA CreateContractDeploymentResponse

--- a/generated.go
+++ b/generated.go
@@ -60,6 +60,7 @@ type ComplexityRoot struct {
 		ID      func(childComplexity int) int
 		Logs    func(childComplexity int) int
 		Script  func(childComplexity int) int
+		Title   func(childComplexity int) int
 	}
 
 	ContractTemplate struct {
@@ -294,6 +295,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ContractDeployment.Script(childComplexity), true
+
+	case "ContractDeployment.title":
+		if e.complexity.ContractDeployment.Title == nil {
+			break
+		}
+
+		return e.complexity.ContractDeployment.Title(childComplexity), true
 
 	case "ContractTemplate.id":
 		if e.complexity.ContractTemplate.ID == nil {
@@ -1131,6 +1139,7 @@ type ContractTemplate {
 
 type ContractDeployment {
   id: UUID!
+  title: String!
   script: String!
   address: Address!
   errors: [ProgramError!]
@@ -1884,6 +1893,50 @@ func (ec *executionContext) fieldContext_ContractDeployment_id(ctx context.Conte
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type UUID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ContractDeployment_title(ctx context.Context, field graphql.CollectedField, obj *model.ContractDeployment) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ContractDeployment_title(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Title, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ContractDeployment_title(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ContractDeployment",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -2849,6 +2902,8 @@ func (ec *executionContext) fieldContext_Mutation_createContractDeployment(ctx c
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_ContractDeployment_id(ctx, field)
+			case "title":
+				return ec.fieldContext_ContractDeployment_title(ctx, field)
 			case "script":
 				return ec.fieldContext_ContractDeployment_script(ctx, field)
 			case "address":
@@ -4611,6 +4666,8 @@ func (ec *executionContext) fieldContext_Project_contractDeployments(ctx context
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_ContractDeployment_id(ctx, field)
+			case "title":
+				return ec.fieldContext_ContractDeployment_title(ctx, field)
 			case "script":
 				return ec.fieldContext_ContractDeployment_script(ctx, field)
 			case "address":
@@ -8826,6 +8883,13 @@ func (ec *executionContext) _ContractDeployment(ctx context.Context, sel ast.Sel
 		case "id":
 
 			out.Values[i] = ec._ContractDeployment_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "title":
+
+			out.Values[i] = ec._ContractDeployment_title(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++

--- a/model/contract.go
+++ b/model/contract.go
@@ -53,7 +53,7 @@ func ContractDeploymentFromFlow(
 	exe := &ContractDeployment{
 		File: File{
 			ID:        uuid.New(),
-			Title:     contractName,
+			Title:     contractName, // Parsed contract name
 			ProjectID: projectID,
 			Type:      ContractFile,
 			Script:    script,

--- a/schema.graphql
+++ b/schema.graphql
@@ -110,6 +110,7 @@ type ContractTemplate {
 
 type ContractDeployment {
   id: UUID!
+  title: String!
   script: String!
   address: Address!
   errors: [ProgramError!]


### PR DESCRIPTION
## Description

Added the parsed cadence contract name to contract deployments. This will enable the FE to pass the proper contract name to the language server when resolving imports.

Related to: https://github.com/onflow/flow-playground/issues/556

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

