### PR TITLE
Ignore updates to file indexes

### DIFF
--- a/e2eTest/contract_templates_test.go
+++ b/e2eTest/contract_templates_test.go
@@ -204,7 +204,7 @@ func TestContractTemplates(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, respA.CreateContractTemplate.ID, respC.UpdateContractTemplate.ID)
-		assert.Equal(t, 1, respC.UpdateContractTemplate.Index)
+		assert.Equal(t, 0, respC.UpdateContractTemplate.Index)
 		assert.Equal(t, respB.UpdateContractTemplate.Script, respC.UpdateContractTemplate.Script)
 	})
 

--- a/e2eTest/contract_templates_test.go
+++ b/e2eTest/contract_templates_test.go
@@ -204,7 +204,7 @@ func TestContractTemplates(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, respA.CreateContractTemplate.ID, respC.UpdateContractTemplate.ID)
-		assert.Equal(t, 0, respC.UpdateContractTemplate.Index)
+		assert.Equal(t, 0, respC.UpdateContractTemplate.Index) // Index updates are disabled
 		assert.Equal(t, respB.UpdateContractTemplate.Script, respC.UpdateContractTemplate.Script)
 	})
 

--- a/e2eTest/script_templates_test.go
+++ b/e2eTest/script_templates_test.go
@@ -191,13 +191,13 @@ func TestScriptTemplates(t *testing.T) {
 			&respC,
 			client.Var("projectId", project.ID),
 			client.Var("templateId", templateID),
-			client.Var("index", 1), // Ignore index updates
+			client.Var("index", 1),
 			client.AddCookie(c.SessionCookie()),
 		)
 		require.NoError(t, err)
 
 		assert.Equal(t, respA.CreateScriptTemplate.ID, respC.UpdateScriptTemplate.ID)
-		assert.Equal(t, 0, respC.UpdateScriptTemplate.Index)
+		assert.Equal(t, 0, respC.UpdateScriptTemplate.Index) // Index updates are disabled
 		assert.Equal(t, respB.UpdateScriptTemplate.Script, respC.UpdateScriptTemplate.Script)
 	})
 

--- a/e2eTest/script_templates_test.go
+++ b/e2eTest/script_templates_test.go
@@ -191,13 +191,13 @@ func TestScriptTemplates(t *testing.T) {
 			&respC,
 			client.Var("projectId", project.ID),
 			client.Var("templateId", templateID),
-			client.Var("index", 1),
+			client.Var("index", 1), // Ignore index updates
 			client.AddCookie(c.SessionCookie()),
 		)
 		require.NoError(t, err)
 
 		assert.Equal(t, respA.CreateScriptTemplate.ID, respC.UpdateScriptTemplate.ID)
-		assert.Equal(t, 1, respC.UpdateScriptTemplate.Index)
+		assert.Equal(t, 0, respC.UpdateScriptTemplate.Index)
 		assert.Equal(t, respB.UpdateScriptTemplate.Script, respC.UpdateScriptTemplate.Script)
 	})
 

--- a/e2eTest/transaction_templates_test.go
+++ b/e2eTest/transaction_templates_test.go
@@ -203,7 +203,7 @@ func TestTransactionTemplates(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, respA.CreateTransactionTemplate.ID, respC.UpdateTransactionTemplate.ID)
-		assert.Equal(t, 1, respC.UpdateTransactionTemplate.Index)
+		assert.Equal(t, 0, respC.UpdateTransactionTemplate.Index)
 		assert.Equal(t, respB.UpdateTransactionTemplate.Script, respC.UpdateTransactionTemplate.Script)
 	})
 

--- a/e2eTest/transaction_templates_test.go
+++ b/e2eTest/transaction_templates_test.go
@@ -203,7 +203,7 @@ func TestTransactionTemplates(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, respA.CreateTransactionTemplate.ID, respC.UpdateTransactionTemplate.ID)
-		assert.Equal(t, 0, respC.UpdateTransactionTemplate.Index)
+		assert.Equal(t, 0, respC.UpdateTransactionTemplate.Index) // Index updates are disabled
 		assert.Equal(t, respB.UpdateTransactionTemplate.Script, respC.UpdateTransactionTemplate.Script)
 	})
 

--- a/storage/sql.go
+++ b/storage/sql.go
@@ -359,9 +359,6 @@ func (s *SQL) UpdateFile(input model.UpdateFile, file *model.File) error {
 	if input.Title != nil {
 		update["title"] = *input.Title
 	}
-	if input.Index != nil {
-		update["index"] = *input.Index
-	}
 
 	err := s.db.
 		Model(&model.File{


### PR DESCRIPTION
Closes: #228 

## Description
Don't update files indexes. This will prevent files from moving around in their lists on the FE. Currently we don't support rearranging files, so there is no case where indexes should be changed.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

