### PR TITLE
Transaction executions recovery

### DIFF
--- a/blockchain/emulator.go
+++ b/blockchain/emulator.go
@@ -94,8 +94,14 @@ func (e *emulator) executeTransaction(
 	script string,
 	arguments []string,
 	authorizers []flowsdk.Address,
-) (*types.TransactionResult, *flowsdk.Transaction, error) {
-	tx := &flowsdk.Transaction{}
+) (result *types.TransactionResult, tx *flowsdk.Transaction, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.New("Panic occurred during transaction execution")
+		}
+	}()
+
+	tx = &flowsdk.Transaction{}
 	tx.Script = []byte(script)
 
 	args, err := parseArguments(arguments)

--- a/blockchain/projects.go
+++ b/blockchain/projects.go
@@ -338,21 +338,15 @@ func (p *Projects) load(projectID uuid.UUID) (blockchain, error) {
 	return em, nil
 }
 
-func (p *Projects) rebuildState(projectID uuid.UUID) (em *emulator, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = errors.New("Failed to rebuild state")
-		}
-	}()
-
+func (p *Projects) rebuildState(projectID uuid.UUID) (*emulator, error) {
 	var executions []*model.TransactionExecution
 
-	err = p.store.GetTransactionExecutionsForProject(projectID, &executions)
+	err := p.store.GetTransactionExecutionsForProject(projectID, &executions)
 	if err != nil {
 		return nil, err
 	}
 
-	em = p.emulatorCache.get(projectID)
+	em := p.emulatorCache.get(projectID)
 	if em == nil { // if cache miss create new emulator
 		em, err = p.emulatorPool.new()
 		if err != nil {


### PR DESCRIPTION
Closes: #255 

## Description
Recover from Cadence runtime panic which maybe occur when  running transaction executions

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

