### PR TITLE
Implement contract redeployment rollback

### DIFF
--- a/blockchain/projects.go
+++ b/blockchain/projects.go
@@ -237,7 +237,7 @@ func (p *Projects) DeployContract(
 		blockHeight := deployment.BlockHeight
 
 		// Delete all contract deployments + transaction_executions >= blockHeight
-		err = p.store.TruncateDeploymentsAndExecutionsByBlockHeight(projectID, blockHeight)
+		err = p.store.TruncateDeploymentsAndExecutionsAfterBlockHeight(projectID, blockHeight)
 		if err != nil {
 			return nil, err
 		}

--- a/blockchain/projects.go
+++ b/blockchain/projects.go
@@ -227,24 +227,29 @@ func (p *Projects) DeployContract(
 
 	if _, ok := flowAccount.Contracts[contractName]; ok {
 		// A contract with this name has already been deployed to this account
-		// Remove previous contract from the account
-		result, tx, err := em.removeContract(address.ToFlowAddress(), contractName)
-		if err != nil {
-			return nil, err
-		}
-		if result.Error != nil {
-			return nil, result.Error
-		}
-
-		// Insert transaction execution of contract removal into db
-		exe := model.TransactionExecutionFromFlow(projectID, result, tx)
-		err = p.store.InsertTransactionExecution(exe)
+		// Rollback to block height before this contract was initially deployed
+		var deployment model.ContractDeployment
+		err := p.store.GetContractDeploymentOnAddress(projectID, contractName, address, &deployment)
 		if err != nil {
 			return nil, err
 		}
 
-		// Remove contract deployment from db
-		err = p.store.DeleteContractDeploymentByName(projectID, address, contractName)
+		blockHeight := deployment.BlockHeight
+
+		// Delete all contract deployments + transaction_executions >= blockHeight
+		err = p.store.TruncateDeploymentsAndExecutionsByBlockHeight(projectID, blockHeight)
+		if err != nil {
+			return nil, err
+		}
+
+		var exesB []*model.TransactionExecution
+		err = p.store.GetTransactionExecutionsForProject(projectID, &exesB)
+		if err != nil {
+			return nil, err
+		}
+
+		// Reload emulator after block height rollback
+		em, err = p.load(projectID)
 		if err != nil {
 			return nil, err
 		}
@@ -259,7 +264,12 @@ func (p *Projects) DeployContract(
 	}
 
 	exe := model.TransactionExecutionFromFlow(projectID, result, tx)
-	deploy := model.ContractDeploymentFromFlow(projectID, contractName, script, result, tx)
+
+	blockHeight, err := em.getLatestBlockHeight()
+	if err != nil {
+		return nil, err
+	}
+	deploy := model.ContractDeploymentFromFlow(projectID, contractName, script, result, tx, blockHeight)
 
 	err = p.store.InsertContractDeploymentWithExecution(deploy, exe)
 	if err != nil {

--- a/e2eTest/constants.go
+++ b/e2eTest/constants.go
@@ -463,6 +463,7 @@ mutation($projectId: UUID!, $script: String!, $address: Address!) {
 	title
     script
     address
+	blockHeight
     errors {
       message
       startPosition { offset line column }
@@ -511,12 +512,13 @@ mutation($projectId: UUID!, $title: String!, $script: String!) {
 
 type CreateContractDeploymentResponse struct {
 	CreateContractDeployment struct {
-		ID      string
-		Title   string
-		Script  string
-		Address string
-		Errors  []model.ProgramError
-		Events  []struct {
+		ID          string
+		Title       string
+		Script      string
+		Address     string
+		BlockHeight int
+		Errors      []model.ProgramError
+		Events      []struct {
 			Type   string
 			Values []string
 		}

--- a/e2eTest/contract_deployments_test.go
+++ b/e2eTest/contract_deployments_test.go
@@ -141,6 +141,160 @@ func TestContractRedeployment(t *testing.T) {
 
 		require.Equal(t, []string{"HelloWorld"}, accountResp.Account.DeployedContracts)
 	})
+
+	t.Run("Contract redeployment with resource", func(t *testing.T) {
+		c := newClient()
+
+		project := createProject(t, c)
+
+		RestNFT := `
+		pub contract RestNFT {
+			pub let CollectionStoragePath: StoragePath
+			pub let CollectionPublicPath: PublicPath
+			pub let MinterStoragePath: StoragePath
+		
+			// Tracks the unique IDs of the NFT
+			pub var idCount: UInt64
+		
+			// Declare the NFT resource type
+			pub resource NFT {
+				// The unique ID that differentiates each NFT
+				pub let id: UInt64
+				pub let data: String
+		
+				// Initialize both fields in the init function
+				init(initID: UInt64, str: String) {
+					self.id = initID
+					self.data = str
+				}
+		
+				pub fun getData(): {String: String} {
+					return {"id": self.id.toString(), "data": self.data}
+				}
+			}
+		
+			// We define this interface purely as a way to allow users
+			// to create public, restricted references to their NFT Collection.
+			// They would use this to publicly expose only the deposit, getIDs,
+			// and idExists fields in their Collection
+			pub resource interface NFTReceiver {
+		
+				pub fun deposit(token: @NFT)
+		
+				pub fun getIDs(): [UInt64]
+		
+				pub fun idExists(id: UInt64): Bool
+			}
+		
+			pub resource Collection: NFTReceiver {
+				// dictionary of NFT conforming tokens
+				// NFT is a resource type with an UInt64 ID field
+				pub var ownedNFTs: @{UInt64: NFT}
+		
+				// Initialize the NFTs field to an empty collection
+				init () {
+					self.ownedNFTs <- {}
+				}
+		
+				pub fun withdraw(withdrawID: UInt64): @NFT {
+					// If the NFT isn't found, the transaction panics and reverts
+					let token <- self.ownedNFTs.remove(key: withdrawID)
+						?? panic("Cannot withdraw the specified NFT ID")
+		
+					return <-token
+				}
+		
+				pub fun deposit(token: @NFT) {
+					// add the new token to the dictionary with a force assignment
+					// if there is already a value at that key, it will fail and revert
+					self.ownedNFTs[token.id] <-! token
+				}
+		
+				// idExists checks to see if a NFT
+				// with the given ID exists in the collection
+				pub fun idExists(id: UInt64): Bool {
+					return self.ownedNFTs[id] != nil
+				}
+		
+				// getIDs returns an array of the IDs that are in the collection
+				pub fun getIDs(): [UInt64] {
+					return self.ownedNFTs.keys
+				}
+		
+				pub fun getNFTdata(id: UInt64): {String: String} {
+					let ref = &self.ownedNFTs[id] as auth &NFT?
+					let declared = ref!
+					return declared.getData()
+				}
+		
+				pub fun getAll(): [{String: String}] {
+					let array: [{String: String}] = []
+					for key in self.ownedNFTs.keys {
+						let value = self.getNFTdata(id: key)
+						array.append(value)
+					}
+					return array
+				}
+		
+				destroy() {
+					destroy self.ownedNFTs
+				}
+			}
+		
+			// creates a new empty Collection resource and returns it
+			pub fun createEmptyCollection(): @Collection {
+				return <- create Collection()
+			}
+		
+			pub fun mintNFT(mintString: String): @NFT {
+		
+				// create a new NFT
+				var newNFT <- create NFT(initID: self.idCount, str: mintString)
+		
+				self.idCount = self.idCount + 1
+		
+				return <-newNFT
+			}
+		
+			init() {
+				self.CollectionStoragePath = /storage/nftCollection
+				self.CollectionPublicPath = /public/nftCollection
+				self.MinterStoragePath = /storage/nftMinter
+		
+				// initialize the ID count to one
+				self.idCount = 1
+		
+				// store an empty NFT Collection in account storage
+				self.account.save(<-self.createEmptyCollection(), to: self.CollectionStoragePath)
+		
+				// publish a reference to the Collection in storage
+				self.account.link<&{NFTReceiver}>(self.CollectionPublicPath, target: self.CollectionStoragePath)
+			}
+		}`
+
+		var resp CreateContractDeploymentResponse
+		err := c.Post(
+			MutationCreateContractDeployment,
+			&resp,
+			client.Var("projectId", project.ID),
+			client.Var("script", RestNFT),
+			client.Var("address", addr1),
+			client.AddCookie(c.SessionCookie()),
+		)
+		require.NoError(t, err)
+		require.Equal(t, RestNFT, resp.CreateContractDeployment.Script)
+
+		err = c.Post(
+			MutationCreateContractDeployment,
+			&resp,
+			client.Var("projectId", project.ID),
+			client.Var("script", RestNFT),
+			client.Var("address", addr1),
+			client.AddCookie(c.SessionCookie()),
+		)
+		require.NoError(t, err)
+		require.Equal(t, RestNFT, resp.CreateContractDeployment.Script)
+	})
 }
 
 func TestContractInteraction(t *testing.T) {

--- a/e2eTest/contract_deployments_test.go
+++ b/e2eTest/contract_deployments_test.go
@@ -147,153 +147,91 @@ func TestContractRedeployment(t *testing.T) {
 
 		project := createProject(t, c)
 
-		RestNFT := `
-		pub contract RestNFT {
-			pub let CollectionStoragePath: StoragePath
-			pub let CollectionPublicPath: PublicPath
-			pub let MinterStoragePath: StoragePath
-		
-			// Tracks the unique IDs of the NFT
-			pub var idCount: UInt64
-		
-			// Declare the NFT resource type
-			pub resource NFT {
-				// The unique ID that differentiates each NFT
-				pub let id: UInt64
-				pub let data: String
-		
-				// Initialize both fields in the init function
-				init(initID: UInt64, str: String) {
-					self.id = initID
-					self.data = str
-				}
-		
-				pub fun getData(): {String: String} {
-					return {"id": self.id.toString(), "data": self.data}
-				}
+		PersonContract := `
+		pub contract Person {
+			pub fun makeFriends(): @Friendship {
+				return <-create Friendship()
 			}
 		
-			// We define this interface purely as a way to allow users
-			// to create public, restricted references to their NFT Collection.
-			// They would use this to publicly expose only the deposit, getIDs,
-			// and idExists fields in their Collection
-			pub resource interface NFTReceiver {
-		
-				pub fun deposit(token: @NFT)
-		
-				pub fun getIDs(): [UInt64]
-		
-				pub fun idExists(id: UInt64): Bool
-			}
-		
-			pub resource Collection: NFTReceiver {
-				// dictionary of NFT conforming tokens
-				// NFT is a resource type with an UInt64 ID field
-				pub var ownedNFTs: @{UInt64: NFT}
-		
-				// Initialize the NFTs field to an empty collection
-				init () {
-					self.ownedNFTs <- {}
+			pub resource Friendship {
+				pub fun yaay() {
+					log("such a nice friend") // we can log to output, useful on emualtor for debugging
 				}
-		
-				pub fun withdraw(withdrawID: UInt64): @NFT {
-					// If the NFT isn't found, the transaction panics and reverts
-					let token <- self.ownedNFTs.remove(key: withdrawID)
-						?? panic("Cannot withdraw the specified NFT ID")
-		
-					return <-token
-				}
-		
-				pub fun deposit(token: @NFT) {
-					// add the new token to the dictionary with a force assignment
-					// if there is already a value at that key, it will fail and revert
-					self.ownedNFTs[token.id] <-! token
-				}
-		
-				// idExists checks to see if a NFT
-				// with the given ID exists in the collection
-				pub fun idExists(id: UInt64): Bool {
-					return self.ownedNFTs[id] != nil
-				}
-		
-				// getIDs returns an array of the IDs that are in the collection
-				pub fun getIDs(): [UInt64] {
-					return self.ownedNFTs.keys
-				}
-		
-				pub fun getNFTdata(id: UInt64): {String: String} {
-					let ref = &self.ownedNFTs[id] as auth &NFT?
-					let declared = ref!
-					return declared.getData()
-				}
-		
-				pub fun getAll(): [{String: String}] {
-					let array: [{String: String}] = []
-					for key in self.ownedNFTs.keys {
-						let value = self.getNFTdata(id: key)
-						array.append(value)
-					}
-					return array
-				}
-		
-				destroy() {
-					destroy self.ownedNFTs
-				}
-			}
-		
-			// creates a new empty Collection resource and returns it
-			pub fun createEmptyCollection(): @Collection {
-				return <- create Collection()
-			}
-		
-			pub fun mintNFT(mintString: String): @NFT {
-		
-				// create a new NFT
-				var newNFT <- create NFT(initID: self.idCount, str: mintString)
-		
-				self.idCount = self.idCount + 1
-		
-				return <-newNFT
-			}
-		
-			init() {
-				self.CollectionStoragePath = /storage/nftCollection
-				self.CollectionPublicPath = /public/nftCollection
-				self.MinterStoragePath = /storage/nftMinter
-		
-				// initialize the ID count to one
-				self.idCount = 1
-		
-				// store an empty NFT Collection in account storage
-				self.account.save(<-self.createEmptyCollection(), to: self.CollectionStoragePath)
-		
-				// publish a reference to the Collection in storage
-				self.account.link<&{NFTReceiver}>(self.CollectionPublicPath, target: self.CollectionStoragePath)
 			}
 		}`
 
-		var resp CreateContractDeploymentResponse
+		var createContractResp CreateContractDeploymentResponse
 		err := c.Post(
 			MutationCreateContractDeployment,
-			&resp,
+			&createContractResp,
 			client.Var("projectId", project.ID),
-			client.Var("script", RestNFT),
+			client.Var("script", PersonContract),
 			client.Var("address", addr1),
 			client.AddCookie(c.SessionCookie()),
 		)
 		require.NoError(t, err)
-		require.Equal(t, RestNFT, resp.CreateContractDeployment.Script)
+
+		MakeFriendsTransaction := `
+		import Person from 0x01
+		
+		transaction {
+			let acc: AuthAccount
+		
+			prepare(signer: AuthAccount) {
+				self.acc = signer    
+			}
+			
+			execute {
+				self.acc.save<@Person.Friendship>(<-Person.makeFriends(), to: StoragePath(identifier: "friendship")!)
+			}
+		}`
+
+		var executeTransactionResp CreateTransactionExecutionResponse
+		err = c.Post(
+			MutationCreateTransactionExecution,
+			&executeTransactionResp,
+			client.Var("projectId", project.ID),
+			client.Var("script", MakeFriendsTransaction),
+			client.Var("signers", []string{addr1}),
+			client.AddCookie(c.SessionCookie()),
+		)
+		require.NoError(t, err)
+
+		var accResp GetAccountResponse
+		err = c.Post(
+			QueryGetAccount,
+			&accResp,
+			client.Var("projectId", project.ID),
+			client.Var("address", addr1),
+		)
+		require.NoError(t, err)
+		require.Equal(t,
+			"{\"Private\":null,\"Public\":{},\"Storage\":{\"friendship\":{\"Fields\":[37],\"ResourceType\":{\"Fields\":[{\"Identifier\":\"uuid\",\"Type\":{}}],\"Initializers\":null,\"Location\":{\"Address\":\"0x0000000000000005\",\"Name\":\"Person\",\"Type\":\"AddressLocation\"},\"QualifiedIdentifier\":\"Person.Friendship\"}}}}",
+			accResp.Account.State)
+
+		PersonContractUpdate := `
+		pub contract Person { 
+		// empty
+		}`
 
 		err = c.Post(
 			MutationCreateContractDeployment,
-			&resp,
+			&createContractResp,
 			client.Var("projectId", project.ID),
-			client.Var("script", RestNFT),
+			client.Var("script", PersonContractUpdate),
 			client.Var("address", addr1),
 			client.AddCookie(c.SessionCookie()),
 		)
 		require.NoError(t, err)
-		require.Equal(t, RestNFT, resp.CreateContractDeployment.Script)
+
+		err = c.Post(
+			QueryGetAccount,
+			&accResp,
+			client.Var("projectId", project.ID),
+			client.Var("address", addr1),
+		)
+		require.NoError(t, err)
+		require.Equal(t, "{}", accResp.Account.State)
 	})
 }
 

--- a/e2eTest/contract_deployments_test.go
+++ b/e2eTest/contract_deployments_test.go
@@ -224,6 +224,8 @@ func TestContractRedeployment(t *testing.T) {
 		)
 		require.NoError(t, err)
 
+		require.Equal(t, 6, createContractResp.CreateContractDeployment.BlockHeight)
+
 		err = c.Post(
 			QueryGetAccount,
 			&accResp,

--- a/generated.go
+++ b/generated.go
@@ -54,13 +54,14 @@ type ComplexityRoot struct {
 	}
 
 	ContractDeployment struct {
-		Address func(childComplexity int) int
-		Errors  func(childComplexity int) int
-		Events  func(childComplexity int) int
-		ID      func(childComplexity int) int
-		Logs    func(childComplexity int) int
-		Script  func(childComplexity int) int
-		Title   func(childComplexity int) int
+		Address     func(childComplexity int) int
+		BlockHeight func(childComplexity int) int
+		Errors      func(childComplexity int) int
+		Events      func(childComplexity int) int
+		ID          func(childComplexity int) int
+		Logs        func(childComplexity int) int
+		Script      func(childComplexity int) int
+		Title       func(childComplexity int) int
 	}
 
 	ContractTemplate struct {
@@ -260,6 +261,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ContractDeployment.Address(childComplexity), true
+
+	case "ContractDeployment.blockHeight":
+		if e.complexity.ContractDeployment.BlockHeight == nil {
+			break
+		}
+
+		return e.complexity.ContractDeployment.BlockHeight(childComplexity), true
 
 	case "ContractDeployment.errors":
 		if e.complexity.ContractDeployment.Errors == nil {
@@ -1142,6 +1150,7 @@ type ContractDeployment {
   title: String!
   script: String!
   address: Address!
+  blockHeight: Int!
   errors: [ProgramError!]
   events: [Event!]
   logs: [String!]
@@ -2030,6 +2039,50 @@ func (ec *executionContext) fieldContext_ContractDeployment_address(ctx context.
 	return fc, nil
 }
 
+func (ec *executionContext) _ContractDeployment_blockHeight(ctx context.Context, field graphql.CollectedField, obj *model.ContractDeployment) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ContractDeployment_blockHeight(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BlockHeight, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ContractDeployment_blockHeight(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ContractDeployment",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _ContractDeployment_errors(ctx context.Context, field graphql.CollectedField, obj *model.ContractDeployment) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_ContractDeployment_errors(ctx, field)
 	if err != nil {
@@ -2908,6 +2961,8 @@ func (ec *executionContext) fieldContext_Mutation_createContractDeployment(ctx c
 				return ec.fieldContext_ContractDeployment_script(ctx, field)
 			case "address":
 				return ec.fieldContext_ContractDeployment_address(ctx, field)
+			case "blockHeight":
+				return ec.fieldContext_ContractDeployment_blockHeight(ctx, field)
 			case "errors":
 				return ec.fieldContext_ContractDeployment_errors(ctx, field)
 			case "events":
@@ -4672,6 +4727,8 @@ func (ec *executionContext) fieldContext_Project_contractDeployments(ctx context
 				return ec.fieldContext_ContractDeployment_script(ctx, field)
 			case "address":
 				return ec.fieldContext_ContractDeployment_address(ctx, field)
+			case "blockHeight":
+				return ec.fieldContext_ContractDeployment_blockHeight(ctx, field)
 			case "errors":
 				return ec.fieldContext_ContractDeployment_errors(ctx, field)
 			case "events":
@@ -8904,6 +8961,13 @@ func (ec *executionContext) _ContractDeployment(ctx context.Context, sel ast.Sel
 		case "address":
 
 			out.Values[i] = ec._ContractDeployment_address(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "blockHeight":
+
+			out.Values[i] = ec._ContractDeployment_blockHeight(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++

--- a/schema.graphql
+++ b/schema.graphql
@@ -113,6 +113,7 @@ type ContractDeployment {
   title: String!
   script: String!
   address: Address!
+  blockHeight: Int!
   errors: [ProgramError!]
   events: [Event!]
   logs: [String!]

--- a/storage/sql.go
+++ b/storage/sql.go
@@ -509,7 +509,7 @@ func (s *SQL) GetTransactionExecutionsForProject(projectID uuid.UUID, exes *[]*m
 		Error
 }
 
-func (s *SQL) TruncateDeploymentsAndExecutionsByBlockHeight(projectID uuid.UUID, blockHeight int) error {
+func (s *SQL) TruncateDeploymentsAndExecutionsAfterBlockHeight(projectID uuid.UUID, blockHeight int) error {
 	return s.db.Transaction(func(tx *gorm.DB) error {
 		err := tx.Delete(
 			&model.TransactionExecution{File: model.File{ProjectID: projectID}},

--- a/storage/sql.go
+++ b/storage/sql.go
@@ -471,6 +471,16 @@ func (s *SQL) GetContractDeploymentsForProject(projectID uuid.UUID, deployments 
 		Error
 }
 
+func (s *SQL) GetContractDeploymentOnAddress(
+	projectID uuid.UUID, title string,
+	address model.Address,
+	deployment *model.ContractDeployment) error {
+	return s.db.Where(&model.ContractDeployment{
+		File: model.File{ProjectID: projectID, Title: title}, Address: address}).
+		Find(&deployment).
+		Error
+}
+
 func (s *SQL) InsertTransactionExecution(exe *model.TransactionExecution) error {
 	var proj model.Project
 	if err := s.db.First(&proj, &model.Project{ID: exe.ProjectID}).Error; err != nil {
@@ -497,6 +507,36 @@ func (s *SQL) GetTransactionExecutionsForProject(projectID uuid.UUID, exes *[]*m
 		Find(exes).
 		Order("\"index\" asc").
 		Error
+}
+
+func (s *SQL) TruncateDeploymentsAndExecutionsByBlockHeight(projectID uuid.UUID, blockHeight int) error {
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		err := tx.Delete(
+			&model.TransactionExecution{File: model.File{ProjectID: projectID}},
+			fmt.Sprintf("\"index\" >= %d", blockHeight-1)). // index starts at 0
+			Error
+		if err != nil {
+			return err
+		}
+
+		err = tx.Model(&model.Project{ID: projectID}).
+			Updates(map[string]any{
+				"TransactionExecutionCount": blockHeight - 1,
+			}).Error
+		if err != nil {
+			return err
+		}
+
+		err = tx.Delete(
+			&model.ContractDeployment{File: model.File{ProjectID: projectID}},
+			fmt.Sprintf("\"blockHeight\" >= %d", blockHeight)).
+			Error
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
 }
 
 func (s *SQL) Ping() error {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -60,6 +60,8 @@ type Store interface {
 	DeleteContractDeploymentByName(projectID uuid.UUID, address model.Address, contractName string) error
 	InsertContractDeploymentWithExecution(deploy *model.ContractDeployment, exe *model.TransactionExecution) error
 	GetContractDeploymentsForProject(projectID uuid.UUID, deployments *[]*model.ContractDeployment) error
+	GetContractDeploymentOnAddress(projectID uuid.UUID, title string, address model.Address, deployment *model.ContractDeployment) error
+	TruncateDeploymentsAndExecutionsByBlockHeight(projectID uuid.UUID, blockHeight int) error
 
 	InsertTransactionExecution(exe *model.TransactionExecution) error
 	GetTransactionExecutionsForProject(projectID uuid.UUID, exes *[]*model.TransactionExecution) error

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -61,7 +61,7 @@ type Store interface {
 	InsertContractDeploymentWithExecution(deploy *model.ContractDeployment, exe *model.TransactionExecution) error
 	GetContractDeploymentsForProject(projectID uuid.UUID, deployments *[]*model.ContractDeployment) error
 	GetContractDeploymentOnAddress(projectID uuid.UUID, title string, address model.Address, deployment *model.ContractDeployment) error
-	TruncateDeploymentsAndExecutionsByBlockHeight(projectID uuid.UUID, blockHeight int) error
+	TruncateDeploymentsAndExecutionsAfterBlockHeight(projectID uuid.UUID, blockHeight int) error
 
 	InsertTransactionExecution(exe *model.TransactionExecution) error
 	GetTransactionExecutionsForProject(projectID uuid.UUID, exes *[]*model.TransactionExecution) error


### PR DESCRIPTION
Closes: #255 

## Description

When a contract is redeployed, rollback to the block height before it was initially deployed.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

