### PR TITLE
Fix contract redeployment rollback

### DIFF
--- a/e2eTest/constants.go
+++ b/e2eTest/constants.go
@@ -25,6 +25,9 @@ import (
 const initAccounts = 5
 const addr1 = "0000000000000001"
 const addr2 = "0000000000000002"
+const addr3 = "0000000000000003"
+const addr4 = "0000000000000004"
+const addr5 = "0000000000000005"
 
 type Project struct {
 	ID                   string

--- a/e2eTest/contract_deployments_test.go
+++ b/e2eTest/contract_deployments_test.go
@@ -235,6 +235,95 @@ func TestContractRedeployment(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "{}", accResp.Account.State)
 	})
+
+	t.Run("Contract redeployment block height rollback", func(t *testing.T) {
+		c := newClient()
+
+		project := createProject(t, c)
+
+		PersonContract := `pub contract Person {}`
+
+		var createContractResp CreateContractDeploymentResponse
+		err := c.Post(
+			MutationCreateContractDeployment,
+			&createContractResp,
+			client.Var("projectId", project.ID),
+			client.Var("script", PersonContract),
+			client.Var("address", addr1),
+			client.AddCookie(c.SessionCookie()),
+		)
+		require.NoError(t, err)
+		require.Equal(t, 6, createContractResp.CreateContractDeployment.BlockHeight)
+
+		err = c.Post(
+			MutationCreateContractDeployment,
+			&createContractResp,
+			client.Var("projectId", project.ID),
+			client.Var("script", PersonContract),
+			client.Var("address", addr2),
+			client.AddCookie(c.SessionCookie()),
+		)
+		require.NoError(t, err)
+		require.Equal(t, 7, createContractResp.CreateContractDeployment.BlockHeight)
+
+		err = c.Post(
+			MutationCreateContractDeployment,
+			&createContractResp,
+			client.Var("projectId", project.ID),
+			client.Var("script", PersonContract),
+			client.Var("address", addr3),
+			client.AddCookie(c.SessionCookie()),
+		)
+		require.NoError(t, err)
+		require.Equal(t, 8, createContractResp.CreateContractDeployment.BlockHeight)
+
+		err = c.Post(
+			MutationCreateContractDeployment,
+			&createContractResp,
+			client.Var("projectId", project.ID),
+			client.Var("script", PersonContract),
+			client.Var("address", addr4),
+			client.AddCookie(c.SessionCookie()),
+		)
+		require.NoError(t, err)
+		require.Equal(t, 9, createContractResp.CreateContractDeployment.BlockHeight)
+
+		err = c.Post(
+			MutationCreateContractDeployment,
+			&createContractResp,
+			client.Var("projectId", project.ID),
+			client.Var("script", PersonContract),
+			client.Var("address", addr5),
+			client.AddCookie(c.SessionCookie()),
+		)
+		require.NoError(t, err)
+		require.Equal(t, 10, createContractResp.CreateContractDeployment.BlockHeight)
+
+		// Rollback block height
+		err = c.Post(
+			MutationCreateContractDeployment,
+			&createContractResp,
+			client.Var("projectId", project.ID),
+			client.Var("script", PersonContract),
+			client.Var("address", addr3),
+			client.AddCookie(c.SessionCookie()),
+		)
+		require.NoError(t, err)
+		require.Equal(t, 8, createContractResp.CreateContractDeployment.BlockHeight)
+
+		// Rollback block height
+		err = c.Post(
+			MutationCreateContractDeployment,
+			&createContractResp,
+			client.Var("projectId", project.ID),
+			client.Var("script", PersonContract),
+			client.Var("address", addr1),
+			client.AddCookie(c.SessionCookie()),
+		)
+		require.NoError(t, err)
+		require.Equal(t, 6, createContractResp.CreateContractDeployment.BlockHeight)
+	})
+
 }
 
 func TestContractInteraction(t *testing.T) {

--- a/storage/sql.go
+++ b/storage/sql.go
@@ -509,11 +509,10 @@ func (s *SQL) GetTransactionExecutionsForProject(projectID uuid.UUID, exes *[]*m
 		Error
 }
 
-func (s *SQL) TruncateDeploymentsAndExecutionsAfterBlockHeight(projectID uuid.UUID, blockHeight int) error {
+func (s *SQL) TruncateDeploymentsAndExecutionsAtBlockHeight(projectID uuid.UUID, blockHeight int) error {
 	return s.db.Transaction(func(tx *gorm.DB) error {
-		err := tx.Delete(
-			&model.TransactionExecution{File: model.File{ProjectID: projectID}},
-			fmt.Sprintf("\"index\" >= %d", blockHeight-1)). // index starts at 0
+		err := tx.Delete(&model.TransactionExecution{},
+			fmt.Sprintf("project_id='%s' AND \"index\" >= %d", projectID, blockHeight-1)).
 			Error
 		if err != nil {
 			return err
@@ -528,8 +527,8 @@ func (s *SQL) TruncateDeploymentsAndExecutionsAfterBlockHeight(projectID uuid.UU
 		}
 
 		err = tx.Delete(
-			&model.ContractDeployment{File: model.File{ProjectID: projectID}},
-			fmt.Sprintf("\"blockHeight\" >= %d", blockHeight)).
+			&model.ContractDeployment{},
+			fmt.Sprintf("project_id='%s' AND \"block_height\" >= %d", projectID, blockHeight)).
 			Error
 		if err != nil {
 			return err

--- a/storage/sql.go
+++ b/storage/sql.go
@@ -511,8 +511,8 @@ func (s *SQL) GetTransactionExecutionsForProject(projectID uuid.UUID, exes *[]*m
 
 func (s *SQL) TruncateDeploymentsAndExecutionsAtBlockHeight(projectID uuid.UUID, blockHeight int) error {
 	return s.db.Transaction(func(tx *gorm.DB) error {
-		err := tx.Delete(&model.TransactionExecution{},
-			fmt.Sprintf("project_id='%s' AND \"index\" >= %d", projectID, blockHeight-1)).
+		err := tx.Where("project_id=? AND \"index\" >= ?", projectID, blockHeight-1).
+			Delete(&model.TransactionExecution{}).
 			Error
 		if err != nil {
 			return err
@@ -526,9 +526,8 @@ func (s *SQL) TruncateDeploymentsAndExecutionsAtBlockHeight(projectID uuid.UUID,
 			return err
 		}
 
-		err = tx.Delete(
-			&model.ContractDeployment{},
-			fmt.Sprintf("project_id='%s' AND \"block_height\" >= %d", projectID, blockHeight)).
+		err = tx.Where("project_id=? AND block_height >= ?", projectID, blockHeight).
+			Delete(&model.ContractDeployment{}).
 			Error
 		if err != nil {
 			return err

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -61,7 +61,7 @@ type Store interface {
 	InsertContractDeploymentWithExecution(deploy *model.ContractDeployment, exe *model.TransactionExecution) error
 	GetContractDeploymentsForProject(projectID uuid.UUID, deployments *[]*model.ContractDeployment) error
 	GetContractDeploymentOnAddress(projectID uuid.UUID, title string, address model.Address, deployment *model.ContractDeployment) error
-	TruncateDeploymentsAndExecutionsAfterBlockHeight(projectID uuid.UUID, blockHeight int) error
+	TruncateDeploymentsAndExecutionsAtBlockHeight(projectID uuid.UUID, blockHeight int) error
 
 	InsertTransactionExecution(exe *model.TransactionExecution) error
 	GetTransactionExecutionsForProject(projectID uuid.UUID, exes *[]*model.TransactionExecution) error


### PR DESCRIPTION
## Description

- Fixed a bug where all contract deployments were truncated instead of just those after a specific block height.
- Added test for multiple rollbacks in sequence.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

