### PR TITLE
Fix transaction index ordering on rollback 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,13 @@ run:
 
 .PHONY: run-pg
 run-pg:
-	FLOW_DB_USER=dylantinianov \
-	FLOW_DB_PASSWORD=dylantinianov \
+	FLOW_DB_USER=postgres \
+	FLOW_DB_PASSWORD=password \
 	FLOW_DB_PORT=5432 \
-	FLOW_DB_NAME=prodcopy \
+	FLOW_DB_NAME=dapper \
 	FLOW_DB_HOST=localhost \
 	FLOW_STORAGEBACKEND=postgresql \
-	FLOW_DEBUG=false FLOW_SESSIONCOOKIESSECURE=false \
+	FLOW_DEBUG=true FLOW_SESSIONCOOKIESSECURE=false \
 	GO111MODULE=on \
 	go run \
 	-ldflags "-X github.com/dapperlabs/flow-playground-api/build.version=$(LAST_KNOWN_VERSION)" \

--- a/Makefile
+++ b/Makefile
@@ -29,12 +29,13 @@ run:
 
 .PHONY: run-pg
 run-pg:
-	FLOW_DB_USER=postgres \
+	FLOW_DB_USER=dylantinianov \
+	FLOW_DB_PASSWORD=dylantinianov \
 	FLOW_DB_PORT=5432 \
-	FLOW_DB_NAME=dapper \
+	FLOW_DB_NAME=prodcopy \
 	FLOW_DB_HOST=localhost \
 	FLOW_STORAGEBACKEND=postgresql \
-	FLOW_DEBUG=true FLOW_SESSIONCOOKIESSECURE=false \
+	FLOW_DEBUG=false FLOW_SESSIONCOOKIESSECURE=false \
 	GO111MODULE=on \
 	go run \
 	-ldflags "-X github.com/dapperlabs/flow-playground-api/build.version=$(LAST_KNOWN_VERSION)" \

--- a/blockchain/projects.go
+++ b/blockchain/projects.go
@@ -236,6 +236,9 @@ func (p *Projects) DeployContract(
 
 		blockHeight := deployment.BlockHeight
 
+		fmt.Printf("Rollback to blockheight %d to redeploy contract %s to account %s\n",
+			blockHeight, contractName, address.ToFlowAddress().String())
+
 		// Delete all contract deployments + transaction_executions >= blockHeight
 		err = p.store.TruncateDeploymentsAndExecutionsAtBlockHeight(projectID, blockHeight)
 		if err != nil {
@@ -271,6 +274,9 @@ func (p *Projects) DeployContract(
 	}
 
 	deploy := model.ContractDeploymentFromFlow(projectID, contractName, script, result, tx, blockHeight)
+
+	fmt.Printf("Deploying Contract %s to account %s with blockheight %d\n",
+		contractName, address.ToFlowAddress().String(), deploy.BlockHeight)
 
 	err = p.store.InsertContractDeploymentWithExecution(deploy, exe)
 	if err != nil {
@@ -333,6 +339,7 @@ func (p *Projects) getAccount(projectID uuid.UUID, address model.Address) (*mode
 func (p *Projects) load(projectID uuid.UUID) (blockchain, error) {
 	em, err := p.rebuildState(projectID)
 	if err != nil {
+		fmt.Println("\nFAILED TO REBUILD STATE, CALLING RESET(): ", err.Error())
 		_, err = p.Reset(projectID)
 		if err != nil {
 			return nil, err

--- a/e2eTest/constants.go
+++ b/e2eTest/constants.go
@@ -117,6 +117,33 @@ type GetAccountResponse struct {
 	Account Account
 }
 
+const QueryGetProjectStorage = `
+query($projectId: UUID!) {
+  project(id: $projectId) {
+	accounts {
+		address
+		deployedContracts
+		state
+	}
+	transactionTemplates {
+      id
+      script
+      index
+    }
+	scriptTemplates {
+      id
+      script
+      index
+	}
+	contractTemplates {
+      id
+      script
+      index
+	}
+  }
+}
+`
+
 const QueryGetProject = `
 query($projectId: UUID!) {
   project(id: $projectId) {

--- a/e2eTest/contract_deployments_test.go
+++ b/e2eTest/contract_deployments_test.go
@@ -299,6 +299,16 @@ func TestContractRedeployment(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 10, createContractResp.CreateContractDeployment.BlockHeight)
 
+		var projStorage GetProjectResponse
+		err = c.Post(
+			QueryGetProjectStorage,
+			&projStorage,
+			client.Var("projectId", project.ID),
+			client.AddCookie(c.SessionCookie()),
+		)
+		require.NoError(t, err)
+		fmt.Println("Project Storage: ", projStorage.Project.Accounts)
+
 		// Rollback block height
 		err = c.Post(
 			MutationCreateContractDeployment,
@@ -311,6 +321,15 @@ func TestContractRedeployment(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 8, createContractResp.CreateContractDeployment.BlockHeight)
 
+		err = c.Post(
+			QueryGetProjectStorage,
+			&projStorage,
+			client.Var("projectId", project.ID),
+			client.AddCookie(c.SessionCookie()),
+		)
+		require.NoError(t, err)
+		fmt.Println("Project Storage: ", projStorage.Project.Accounts)
+
 		// Rollback block height
 		err = c.Post(
 			MutationCreateContractDeployment,
@@ -322,6 +341,15 @@ func TestContractRedeployment(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Equal(t, 6, createContractResp.CreateContractDeployment.BlockHeight)
+
+		err = c.Post(
+			QueryGetProjectStorage,
+			&projStorage,
+			client.Var("projectId", project.ID),
+			client.AddCookie(c.SessionCookie()),
+		)
+		require.NoError(t, err)
+		fmt.Println("Project Storage: ", projStorage.Project.Accounts)
 	})
 
 }

--- a/e2eTest/contract_deployments_test.go
+++ b/e2eTest/contract_deployments_test.go
@@ -307,7 +307,6 @@ func TestContractRedeployment(t *testing.T) {
 			client.AddCookie(c.SessionCookie()),
 		)
 		require.NoError(t, err)
-		fmt.Println("Project Storage: ", projStorage.Project.Accounts)
 
 		// Rollback block height
 		err = c.Post(
@@ -328,7 +327,6 @@ func TestContractRedeployment(t *testing.T) {
 			client.AddCookie(c.SessionCookie()),
 		)
 		require.NoError(t, err)
-		fmt.Println("Project Storage: ", projStorage.Project.Accounts)
 
 		// Rollback block height
 		err = c.Post(
@@ -349,7 +347,6 @@ func TestContractRedeployment(t *testing.T) {
 			client.AddCookie(c.SessionCookie()),
 		)
 		require.NoError(t, err)
-		fmt.Println("Project Storage: ", projStorage.Project.Accounts)
 	})
 
 }

--- a/storage/sql.go
+++ b/storage/sql.go
@@ -387,8 +387,8 @@ func (s *SQL) GetFile(id uuid.UUID, pID uuid.UUID, file *model.File) error {
 func (s *SQL) GetFilesForProject(pID uuid.UUID, files *[]*model.File, fileType model.FileType) error {
 	// Note: use map to include zero entries for fileType
 	return s.db.Where(map[string]interface{}{"project_id": pID.String(), "type": fileType}).
-		Find(files).
 		Order("\"index\" asc").
+		Find(files).
 		Error
 }
 
@@ -402,8 +402,8 @@ func (s *SQL) InsertScriptExecution(exe *model.ScriptExecution) error {
 
 func (s *SQL) GetScriptExecutionsForProject(projectID uuid.UUID, exes *[]*model.ScriptExecution) error {
 	return s.db.Where(&model.ScriptExecution{File: model.File{ProjectID: projectID}}).
-		Find(exes).
 		Order("\"index\" asc").
+		Find(exes).
 		Error
 }
 
@@ -466,8 +466,8 @@ func (s *SQL) DeleteContractDeploymentByName(
 
 func (s *SQL) GetContractDeploymentsForProject(projectID uuid.UUID, deployments *[]*model.ContractDeployment) error {
 	return s.db.Where(&model.ContractDeployment{File: model.File{ProjectID: projectID}}).
-		Find(deployments).
 		Order("\"index\" asc").
+		Find(deployments).
 		Error
 }
 

--- a/storage/sql.go
+++ b/storage/sql.go
@@ -504,8 +504,8 @@ func (s *SQL) InsertTransactionExecution(exe *model.TransactionExecution) error 
 
 func (s *SQL) GetTransactionExecutionsForProject(projectID uuid.UUID, exes *[]*model.TransactionExecution) error {
 	return s.db.Where(&model.TransactionExecution{File: model.File{ProjectID: projectID}}).
-		Find(exes).
 		Order("\"index\" asc").
+		Find(exes).
 		Error
 }
 


### PR DESCRIPTION
## Description
On occasion the indexes of transaction executions retrieved from the database were out of order. This caused state rebuilding to fail when executing transactions out of order on an emulator.

To fix this I moved ordering transaction executions by index before finding them in the sql library.
Also added retrieving account storage to the rollback test.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

