### PR TITLE
Fix session bug caused by sentry-go@v0.18.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/go-chi/httplog v0.2.5
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/google/uuid v1.3.1
-	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/sessions v1.2.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/icza/bitio v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -455,8 +455,6 @@ github.com/googleapis/gax-go/v2 v2.11.0 h1:9V9PWXEsWnPpQhu/PeQIkS4eGzMlTLGgt80cU
 github.com/googleapis/gax-go/v2 v2.11.0/go.mod h1:DxmR61SGKkGLa2xigwuZIQpkCI2S5iydzRfb3peWZJI=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
-github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
-github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.0 h1:S7P+1Hm5V/AT9cjEcUD5uDaQSX0OE577aCXgoaKpYbQ=

--- a/middleware/monitoring/sentry.go
+++ b/middleware/monitoring/sentry.go
@@ -19,10 +19,11 @@
 package monitoring
 
 import (
+	"net/http"
+
 	sentryhttp "github.com/getsentry/sentry-go/http"
-	"github.com/gorilla/mux"
 )
 
-func Middleware() mux.MiddlewareFunc {
+func Middleware() func(http.Handler) http.Handler {
 	return sentryhttp.New(sentryhttp.Options{}).Handle
 }

--- a/server/server.go
+++ b/server/server.go
@@ -21,16 +21,17 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/dapperlabs/flow-playground-api"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	playground "github.com/dapperlabs/flow-playground-api"
 	"github.com/dapperlabs/flow-playground-api/server/config"
 	"github.com/dapperlabs/flow-playground-api/server/ping"
 	"github.com/dapperlabs/flow-playground-api/telemetry"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/otel/sdk/trace"
-	"log"
-	"net/http"
-	"strings"
-	"time"
 
 	"github.com/go-chi/httplog"
 
@@ -170,7 +171,6 @@ func main() {
 
 		r.Use(httpcontext.Middleware())
 		r.Use(sessions.Middleware(cookieStore))
-		r.Use(monitoring.Middleware())
 
 		r.Handle(
 			"/",


### PR DESCRIPTION
closes #348 

## Description

v2.1.9 of the playground API is not working in staging.  I have debugged this and determined that the sentry update that was mandatory as a part of updating to the latest version of Cadence was responsible.  It broke the session middleware

Namely, it has to do with how sentry affects the request context when being run twice in the middeware stack.  Sentry stores the current transaction in the context & if one exists already, then it uses this transaction.  However, this causes the request context to get rolled back to where it was during the first middleware call -> effectively removes any middleware values set between sentry middleware calls.

**TL;DR** this PR removes a redundant sentry middleware that was breaking the Playground.  I also removed gorilla/mux because we aren't using it and it was just being used for a type.
______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-playground/blob/master/CONTRIBUTING.md).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 

